### PR TITLE
Refactor macOS zerocopy normalization boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ set(CRAFTGROUND_PY_SOURCES src/cpp/ipc.cpp src/cpp/ipc_noboost.cpp src/cpp/print
 
 if(APPLE)
     # Add Apple-specific source files
-    list(APPEND CRAFTGROUND_PY_SOURCES src/cpp/ipc_apple.mm src/cpp/ipc_apple_torch.cpp)
+    list(APPEND CRAFTGROUND_PY_SOURCES src/cpp/ipc_apple.mm src/cpp/ipc_apple_ops.mm src/cpp/ipc_apple_torch.cpp)
 
     # Apple-specific compile options
     set(CRAFTGROUND_PY_COMPILE_OPTIONS -fobjc-arc)

--- a/docs/superpowers/plans/2026-03-19-zerocopy-raw-normalize.md
+++ b/docs/superpowers/plans/2026-03-19-zerocopy-raw-normalize.md
@@ -1,0 +1,164 @@
+# Zerocopy Raw Normalize Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the macOS zerocopy path so raw transport tensors stay internal while the public `ZEROCOPY` path continues to return normalized `RGB + flipped` output.
+
+**Architecture:** Keep the native macOS bridge unchanged for now and move the raw-to-public normalization boundary into `ObservationConverter`. Minimize diff by touching the current macOS zerocopy branches only, adding a small normalization helper and focused tests.
+
+**Tech Stack:** Python, PyTorch, pytest, existing CraftGround environment converter code
+
+---
+
+## Chunk 1: MacOS Zerocopy Boundary
+
+### Task 1: Add failing tests for macOS zerocopy public normalization
+
+**Files:**
+- Modify: `tests/python/unit/test_observation_converter.py` or nearest existing converter test file
+- Modify: `src/craftground/environment/observation_converter.py`
+
+- [ ] **Step 1: Locate or create the nearest unit-test file for `ObservationConverter`**
+
+Run: `rg -n "ObservationConverter|initialize_zerocopy|ScreenEncodingMode.ZEROCOPY" tests src/craftground`
+Expected: identify the closest existing test home; only create a new test file if no suitable one exists.
+
+- [ ] **Step 2: Write a failing test for the macOS path that preserves public output semantics**
+
+Test idea:
+
+```python
+def test_macos_zerocopy_returns_rgb_flipped_from_raw_transport(...):
+    converter = ObservationConverter(...)
+    raw = fake_tensor_with_known_bgra_rows(...)
+    converter.internal_type = ObservationTensorType.APPLE_TENSOR
+    converter.last_observations[0] = raw
+
+    obs, _ = converter.convert(fake_observation(...))
+
+    assert torch.equal(obs, expected_rgb_flipped)
+```
+
+- [ ] **Step 3: Write a failing test that initialization stores raw transport data without normalization**
+
+Test idea:
+
+```python
+def test_initialize_zerocopy_stores_raw_apple_tensor(...):
+    converter = ObservationConverter(...)
+    raw = fake_raw_tensor(...)
+    mock_initialize_from_mach_port.return_value = raw
+
+    converter.initialize_zerocopy(fake_mach_port_bytes)
+
+    assert converter.last_observations[0] is raw
+```
+
+- [ ] **Step 4: Run the targeted tests and verify they fail for the intended reason**
+
+Run: `pytest <targeted-test-file> -k zerocopy -v`
+Expected: FAIL due to missing helper/incorrect state handling, not import or syntax errors.
+
+- [ ] **Step 5: Commit the failing tests**
+
+```bash
+git add <targeted-test-file>
+git commit -m "test: add macos zerocopy normalization coverage"
+```
+
+### Task 2: Implement raw/public separation with minimal diff
+
+**Files:**
+- Modify: `src/craftground/environment/observation_converter.py`
+- Test: `tests/python/unit/test_observation_converter.py` or nearest existing converter test file
+
+- [ ] **Step 1: Add a small helper for macOS raw-to-public normalization**
+
+Implementation target:
+
+```python
+def _normalize_apple_zerocopy_tensor(self, tensor: "TorchArrayType") -> "TorchArrayType":
+    return tensor.clone()[:, :, [2, 1, 0]].flip(0)
+```
+
+Keep this helper private and adjacent to zerocopy handling.
+
+- [ ] **Step 2: Make `initialize_zerocopy()` store the raw Apple tensor only**
+
+Requirements:
+
+- no normalization in initialization
+- keep storing the raw transport tensor
+- ensure type tracking updates the field used by `convert()`
+
+- [ ] **Step 3: Update the public `ZEROCOPY` branch to call the helper at return time**
+
+Requirements:
+
+- preserve current `RGB + flipped` behavior for Apple tensors
+- do not broaden the change into unrelated output types
+- keep non-Apple branches unchanged unless required for correctness
+
+- [ ] **Step 4: Fix the touched zerocopy state variable inconsistency if still present**
+
+The code currently mixes `internal_type` and `observation_tensor_type`. The implementation should ensure the active state variable used by `convert()` is updated consistently in the touched path.
+
+- [ ] **Step 5: Run the targeted tests and verify they pass**
+
+Run: `pytest <targeted-test-file> -k zerocopy -v`
+Expected: PASS
+
+- [ ] **Step 6: Run any neighboring converter tests**
+
+Run: `pytest <targeted-test-file> -v`
+Expected: PASS with no zerocopy regressions in nearby behavior.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add src/craftground/environment/observation_converter.py <targeted-test-file>
+git commit -m "refactor: separate raw macos zerocopy transport from public normalization"
+```
+
+## Chunk 2: Verification And Handoff
+
+### Task 3: Verify branch state and prepare for PR
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-19-zerocopy-raw-normalize-design.md`
+- Modify: `docs/superpowers/plans/2026-03-19-zerocopy-raw-normalize.md`
+
+- [ ] **Step 1: Run a focused verification sweep**
+
+Run:
+
+```bash
+pytest <targeted-test-file> -v
+git status --short
+git log --oneline -5
+```
+
+Expected:
+
+- tests passing
+- only intended files modified
+- branch contains the new zerocopy commits
+
+- [ ] **Step 2: Update docs if implementation differs from the planned low-diff shape**
+
+Keep spec and plan aligned with actual code decisions.
+
+- [ ] **Step 3: Prepare PR summary**
+
+Include:
+
+- internal raw/public separation
+- no public `ZEROCOPY` behavior change
+- future raw-mode support enabled
+
+- [ ] **Step 4: Commit any doc adjustments**
+
+```bash
+git add docs/superpowers/specs/2026-03-19-zerocopy-raw-normalize-design.md docs/superpowers/plans/2026-03-19-zerocopy-raw-normalize.md
+git commit -m "docs: record zerocopy raw normalize design and plan"
+```

--- a/docs/superpowers/specs/2026-03-19-zerocopy-raw-normalize-design.md
+++ b/docs/superpowers/specs/2026-03-19-zerocopy-raw-normalize-design.md
@@ -1,0 +1,118 @@
+# Zerocopy Raw Normalize Design
+
+## Summary
+
+Refactor the macOS zerocopy path so the internal transport tensor remains in its native raw layout, while the public `ZEROCOPY` API continues to expose the current normalized image contract (`RGB + flipped`). This keeps the current user-facing behavior stable, reduces coupling between the custom MPS bridge and presentation logic, and creates a clean path to expose a future raw mode without redesigning the pipeline again.
+
+## Current Problem
+
+The macOS zerocopy path currently mixes three concerns in one flow:
+
+1. Transporting the framebuffer into Python as an MPS-backed tensor.
+2. Representing the native producer layout.
+3. Returning the user-facing normalized layout.
+
+This makes the custom bridge responsible for data semantics it should not own. It also forces the current implementation to rely on `clone()` in the public path as both a correctness workaround and a format-conversion boundary.
+
+## Decision
+
+Use the approved option:
+
+- Keep the internal macOS zerocopy representation as native raw data.
+- Preserve the existing public `ZEROCOPY` output semantics.
+- Move normalization (`RGB + flip`) to the public conversion boundary.
+- Do not expose a new raw public mode in this change.
+
+This is the lowest-diff option that improves maintainability without giving up future extensibility.
+
+## Scope
+
+In scope:
+
+- macOS zerocopy internals in `observation_converter.py`
+- separation between raw transport tensor and normalized public tensor
+- tests for the new internal/public boundary behavior
+- cleanup of the internal zerocopy type-tracking bug if encountered in the touched path
+
+Out of scope:
+
+- changing the public API shape of `ScreenEncodingMode.ZEROCOPY`
+- introducing a new public raw mode
+- redesigning the native C++ bridge
+- changing non-macOS behavior unless required for shared helper safety
+
+## Design
+
+### Internal Representation
+
+`initialize_zerocopy()` should store the macOS tensor exactly as produced by the native bridge. No channel reorder, Y-flip, or user-facing normalization should happen at initialization time.
+
+The raw tensor is the transport artifact. It is allowed to be in producer-native layout as long as the public boundary is responsible for converting it into the documented output format.
+
+### Public Representation
+
+The existing `ScreenEncodingMode.ZEROCOPY` path should continue to return the same logical image as before. The normalization step should happen in a helper near the public return site, not during bridge setup.
+
+For the macOS path this means:
+
+- source: raw Apple tensor
+- public output: normalized `RGB + flipped`
+
+This keeps behavior stable for users while isolating future raw-mode support to a small API addition later.
+
+### State Ownership
+
+The converter should make the distinction between:
+
+- raw zerocopy tensor state
+- normalized public observation state
+
+The implementation may use separate fields or a clearly named helper-based boundary, but the raw/public distinction must be explicit in code. Avoid clever state machines. This should stay easy to follow inside the existing file.
+
+### Future Raw Mode
+
+This refactor should make a later `ZEROCOPY_RAW` or equivalent mode straightforward:
+
+- the raw tensor already exists as a first-class internal concept
+- the later feature would only add a new public branch that returns the raw tensor directly
+- the normalized branch would remain unchanged
+
+## Testing Strategy
+
+Add targeted tests around the converter boundary:
+
+- macOS zerocopy initialization stores the raw transport tensor without premature normalization
+- public `ZEROCOPY` still returns the same normalized semantics as before
+- normalization helper is the only place that performs the macOS format conversion
+
+Tests should focus on layout semantics and call boundaries, not the real native bridge.
+
+## Risk Management
+
+Primary risk:
+
+- accidentally changing the user-visible output of `ZEROCOPY`
+
+Mitigation:
+
+- keep the public return contract unchanged
+- isolate the new normalization helper
+- cover the output semantics with tests
+
+Secondary risk:
+
+- touching shared converter state and unintentionally affecting non-macOS paths
+
+Mitigation:
+
+- keep the diff local to the macOS-specific branches whenever possible
+- avoid broad refactors outside the touched boundary
+
+## Success Criteria
+
+The change is successful when:
+
+- current `ZEROCOPY` callers still receive `RGB + flipped` output
+- the macOS zerocopy path internally preserves a raw transport tensor
+- the code clearly separates raw transport from public normalization
+- the refactor makes a future raw public mode a small additive change

--- a/src/cpp/ipc.cpp
+++ b/src/cpp/ipc.cpp
@@ -10,6 +10,9 @@ py::object
 initialize_from_mach_port(unsigned int machPort, int width, int height) {
     return mtl_tensor_from_mach_port(machPort, width, height);
 }
+py::object normalize_apple_mtl_tensor(py::object tensor) {
+    return normalize_apple_mtl_tensor_impl(std::move(tensor));
+}
 py::capsule mtl_tensor_from_cuda_mem_handle(
     const char *cuda_ipc_handle, int width, int height
 ) {
@@ -20,6 +23,9 @@ py::capsule mtl_tensor_from_cuda_mem_handle(
 #include "ipc_cuda.h"
 py::object
 initialize_from_mach_port(unsigned int machPort, int width, int height) {
+    return py::none();
+}
+py::object normalize_apple_mtl_tensor(py::object tensor) {
     return py::none();
 }
 
@@ -49,6 +55,9 @@ py::capsule mtl_tensor_from_cuda_mem_handle(
 #else
 py::object
 initialize_from_mach_port(unsigned int machPort, int width, int height) {
+    return py::none();
+}
+py::object normalize_apple_mtl_tensor(py::object tensor) {
     return py::none();
 }
 
@@ -100,6 +109,7 @@ void destroy_shared_memory(const char *memory_name, bool release_semaphores) {
 PYBIND11_MODULE(craftground_native, m) {
     m.doc() = "Craftground Native Module";
     m.def("initialize_from_mach_port", &initialize_from_mach_port);
+    m.def("normalize_apple_mtl_tensor", &normalize_apple_mtl_tensor);
     m.def("mtl_tensor_from_cuda_mem_handle", &mtl_tensor_from_cuda_mem_handle);
     m.def("initialize_shared_memory", &initialize_shared_memory);
     m.def("write_to_shared_memory", &write_to_shared_memory);

--- a/src/cpp/ipc.cpp
+++ b/src/cpp/ipc.cpp
@@ -25,9 +25,7 @@ py::object
 initialize_from_mach_port(unsigned int machPort, int width, int height) {
     return py::none();
 }
-py::object normalize_apple_mtl_tensor(py::object tensor) {
-    return py::none();
-}
+py::object normalize_apple_mtl_tensor(py::object tensor) { return py::none(); }
 
 py::capsule mtl_tensor_from_cuda_mem_handle(
     const char *cuda_ipc_handle, int width, int height
@@ -57,9 +55,7 @@ py::object
 initialize_from_mach_port(unsigned int machPort, int width, int height) {
     return py::none();
 }
-py::object normalize_apple_mtl_tensor(py::object tensor) {
-    return py::none();
-}
+py::object normalize_apple_mtl_tensor(py::object tensor) { return py::none(); }
 
 py::capsule mtl_tensor_from_cuda_mem_handle(
     const char *cuda_ipc_handle, int width, int height

--- a/src/cpp/ipc.h
+++ b/src/cpp/ipc.h
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <string>
 
+#include <pybind11/pybind11.h>
+
 namespace py = pybind11;
 py::object
 initialize_from_mach_port(unsigned int machPort, int width, int height);

--- a/src/cpp/ipc.h
+++ b/src/cpp/ipc.h
@@ -7,6 +7,7 @@
 namespace py = pybind11;
 py::object
 initialize_from_mach_port(unsigned int machPort, int width, int height);
+py::object normalize_apple_mtl_tensor(py::object tensor);
 py::capsule mtl_tensor_from_cuda_mem_handle(
     const char *cuda_ipc_handle, int width, int height
 );

--- a/src/cpp/ipc_apple.h
+++ b/src/cpp/ipc_apple.h
@@ -1,6 +1,10 @@
 #ifndef __IPC_APPLE_H__
 #define __IPC_APPLE_H__
 
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
 #define USE_CUSTOM_DL_PACK_TENSOR 1
 
 py::object

--- a/src/cpp/ipc_apple.h
+++ b/src/cpp/ipc_apple.h
@@ -5,5 +5,6 @@
 
 py::object
 mtl_tensor_from_mach_port(unsigned int machPort, int width, int height);
+py::object normalize_apple_mtl_tensor_impl(py::object tensor);
 
 #endif // __IPC_APPLE_H__

--- a/src/cpp/ipc_apple.mm
+++ b/src/cpp/ipc_apple.mm
@@ -65,8 +65,7 @@ static void deleteDLManagedTensor(DLManagedTensor *self) {
     free(self);
 }
 
-static DLManagedTensor *
-createDLPackTensorMetal(
+static DLManagedTensor *createDLPackTensorMetal(
     id<MTLBuffer> mtlBuffer, size_t width, size_t height, size_t bytesPerRow
 ) {
     DLManagedTensor *tensor =

--- a/src/cpp/ipc_apple.mm
+++ b/src/cpp/ipc_apple.mm
@@ -57,23 +57,31 @@ id<MTLTexture> createMetalTextureFromIOSurface(
 */
 
 static void deleteDLManagedTensor(DLManagedTensor *self) {
-    // CFRelease((__bridge CFTypeRef)self->dl_tensor.data);
+    if (self->dl_tensor.data) {
+        CFRelease((CFTypeRef)self->dl_tensor.data);
+    }
     free(self->dl_tensor.shape);
+    free(self->dl_tensor.strides);
     free(self);
 }
 
 static DLManagedTensor *
-createDLPackTensorMetal(id<MTLBuffer> mtlBuffer, size_t width, size_t height) {
+createDLPackTensorMetal(
+    id<MTLBuffer> mtlBuffer, size_t width, size_t height, size_t bytesPerRow
+) {
     DLManagedTensor *tensor =
         (DLManagedTensor *)malloc(sizeof(DLManagedTensor));
 
     tensor->dl_tensor.data = (void *)CFBridgingRetain(mtlBuffer);
     tensor->dl_tensor.ndim = 3; // H x W x C
     tensor->dl_tensor.shape = (int64_t *)malloc(3 * sizeof(int64_t));
+    tensor->dl_tensor.strides = (int64_t *)malloc(3 * sizeof(int64_t));
     tensor->dl_tensor.shape[0] = height;
     tensor->dl_tensor.shape[1] = width;
-    tensor->dl_tensor.shape[2] = 4; // RGBA
-    tensor->dl_tensor.strides = NULL;
+    tensor->dl_tensor.shape[2] = 3; // BGR
+    tensor->dl_tensor.strides[0] = bytesPerRow;
+    tensor->dl_tensor.strides[1] = 4;
+    tensor->dl_tensor.strides[2] = 1;
     tensor->dl_tensor.byte_offset = 0;
 
     tensor->dl_tensor.dtype =
@@ -137,7 +145,8 @@ mtl_tensor_from_mach_port(unsigned int machPort, int width, int height) {
         );
     }
 
-    DLManagedTensor *tensor = createDLPackTensorMetal(mtlBuffer, width, height);
+    DLManagedTensor *tensor =
+        createDLPackTensorMetal(mtlBuffer, width, height, bytesPerRow);
 
 #if USE_CUSTOM_DL_PACK_TENSOR
     return py::reinterpret_steal<py::object>(torchTensorFromDLPack(tensor));

--- a/src/cpp/ipc_apple_ops.mm
+++ b/src/cpp/ipc_apple_ops.mm
@@ -71,29 +71,31 @@ id<MTLComputePipelineState> getNormalizePipeline(id<MTLDevice> device) {
       id<MTLLibrary> library = [device newLibraryWithSource:source
                                                     options:options
                                                       error:&library_error];
-      [options release];
       if (!library) {
-          pipeline_error = [library_error retain];
+          pipeline_error = library_error;
           return;
       }
 
       id<MTLFunction> function =
           [library newFunctionWithName:@"normalize_bgr_flip"];
-      [library release];
       if (!function) {
-          pipeline_error = [[NSError alloc]
-              initWithDomain:@"craftground"
-                        code:1
-                    userInfo:@{
-                        NSLocalizedDescriptionKey :
-                            @"Failed to load normalize_bgr_flip kernel"
-                    }];
+          pipeline_error = [NSError
+              errorWithDomain:@"craftground"
+                         code:1
+                     userInfo:@{
+                         NSLocalizedDescriptionKey :
+                             @"Failed to load normalize_bgr_flip kernel"
+                     }];
           return;
       }
 
-      pipeline = [device newComputePipelineStateWithFunction:function
-                                                       error:&pipeline_error];
-      [function release];
+      NSError *compute_pipeline_error = nil;
+      pipeline =
+          [device newComputePipelineStateWithFunction:function
+                                                error:&compute_pipeline_error];
+      if (!pipeline) {
+          pipeline_error = compute_pipeline_error;
+      }
     });
 
     if (!pipeline) {
@@ -121,8 +123,8 @@ at::Tensor normalizeAppleTensor(const at::Tensor &src) {
     id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
     id<MTLComputePipelineState> pipeline =
         getNormalizePipeline(stream->device());
-    id<MTLBuffer> src_buffer = (id<MTLBuffer>)src.storage().data();
-    id<MTLBuffer> dst_buffer = (id<MTLBuffer>)dst.storage().data();
+    id<MTLBuffer> src_buffer = (__bridge id<MTLBuffer>)src.storage().data();
+    id<MTLBuffer> dst_buffer = (__bridge id<MTLBuffer>)dst.storage().data();
 
     NormalizeParams params{
         static_cast<uint32_t>(src.size(1)),

--- a/src/cpp/ipc_apple_ops.mm
+++ b/src/cpp/ipc_apple_ops.mm
@@ -68,24 +68,26 @@ id<MTLComputePipelineState> getNormalizePipeline(id<MTLDevice> device) {
 
       MTLCompileOptions *options = [[MTLCompileOptions alloc] init];
       NSError *library_error = nil;
-      id<MTLLibrary> library =
-          [device newLibraryWithSource:source options:options error:&library_error];
+      id<MTLLibrary> library = [device newLibraryWithSource:source
+                                                    options:options
+                                                      error:&library_error];
       [options release];
       if (!library) {
           pipeline_error = [library_error retain];
           return;
       }
 
-      id<MTLFunction> function = [library newFunctionWithName:@"normalize_bgr_flip"];
+      id<MTLFunction> function =
+          [library newFunctionWithName:@"normalize_bgr_flip"];
       [library release];
       if (!function) {
           pipeline_error = [[NSError alloc]
               initWithDomain:@"craftground"
-                         code:1
-                     userInfo:@{
-                         NSLocalizedDescriptionKey :
-                             @"Failed to load normalize_bgr_flip kernel"
-                     }];
+                        code:1
+                    userInfo:@{
+                        NSLocalizedDescriptionKey :
+                            @"Failed to load normalize_bgr_flip kernel"
+                    }];
           return;
       }
 
@@ -117,7 +119,8 @@ at::Tensor normalizeAppleTensor(const at::Tensor &src) {
 
     auto *stream = at::mps::getCurrentMPSStream();
     id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
-    id<MTLComputePipelineState> pipeline = getNormalizePipeline(stream->device());
+    id<MTLComputePipelineState> pipeline =
+        getNormalizePipeline(stream->device());
     id<MTLBuffer> src_buffer = (id<MTLBuffer>)src.storage().data();
     id<MTLBuffer> dst_buffer = (id<MTLBuffer>)dst.storage().data();
 
@@ -139,7 +142,7 @@ at::Tensor normalizeAppleTensor(const at::Tensor &src) {
 
     NSUInteger thread_width = pipeline.threadExecutionWidth;
     NSUInteger thread_height = pipeline.maxTotalThreadsPerThreadgroup /
-        std::max<NSUInteger>(1, thread_width);
+                               std::max<NSUInteger>(1, thread_width);
     if (thread_height == 0) {
         thread_height = 1;
     }
@@ -152,7 +155,7 @@ at::Tensor normalizeAppleTensor(const at::Tensor &src) {
         1
     );
     [encoder dispatchThreads:threads_per_grid
-      threadsPerThreadgroup:threads_per_threadgroup];
+        threadsPerThreadgroup:threads_per_threadgroup];
 
     return dst;
 }

--- a/src/cpp/ipc_apple_ops.mm
+++ b/src/cpp/ipc_apple_ops.mm
@@ -1,0 +1,164 @@
+#include <ATen/mps/MPSStream.h>
+#include <torch/extension.h>
+#import <Metal/Metal.h>
+#include <pybind11/pybind11.h>
+#include <algorithm>
+
+namespace py = pybind11;
+
+namespace {
+
+struct NormalizeParams {
+    uint32_t width;
+    uint32_t height;
+    uint32_t src_row_stride;
+    uint32_t src_pixel_stride;
+    uint32_t src_offset;
+    uint32_t dst_row_stride;
+    uint32_t dst_pixel_stride;
+    uint32_t dst_offset;
+};
+
+id<MTLComputePipelineState> getNormalizePipeline(id<MTLDevice> device) {
+    static id<MTLComputePipelineState> pipeline = nil;
+    static dispatch_once_t once_token;
+    static NSError *pipeline_error = nil;
+
+    dispatch_once(&once_token, ^{
+      NSString *source = [NSString stringWithUTF8String:R"(
+        #include <metal_stdlib>
+        using namespace metal;
+
+        struct NormalizeParams {
+            uint width;
+            uint height;
+            uint src_row_stride;
+            uint src_pixel_stride;
+            uint src_offset;
+            uint dst_row_stride;
+            uint dst_pixel_stride;
+            uint dst_offset;
+        };
+
+        kernel void normalize_bgr_flip(
+            device const uchar *src [[buffer(0)]],
+            device uchar *dst [[buffer(1)]],
+            constant NormalizeParams &params [[buffer(2)]],
+            uint2 gid [[thread_position_in_grid]]
+        ) {
+            if (gid.x >= params.width || gid.y >= params.height) {
+                return;
+            }
+
+            uint src_y = params.height - 1u - gid.y;
+            uint src_base = params.src_offset + src_y * params.src_row_stride +
+                gid.x * params.src_pixel_stride;
+            uint dst_base = params.dst_offset + gid.y * params.dst_row_stride +
+                gid.x * params.dst_pixel_stride;
+
+            uchar b = src[src_base + 0];
+            uchar g = src[src_base + 1];
+            uchar r = src[src_base + 2];
+
+            dst[dst_base + 0] = r;
+            dst[dst_base + 1] = g;
+            dst[dst_base + 2] = b;
+        }
+      )"];
+
+      MTLCompileOptions *options = [[MTLCompileOptions alloc] init];
+      NSError *library_error = nil;
+      id<MTLLibrary> library =
+          [device newLibraryWithSource:source options:options error:&library_error];
+      [options release];
+      if (!library) {
+          pipeline_error = [library_error retain];
+          return;
+      }
+
+      id<MTLFunction> function = [library newFunctionWithName:@"normalize_bgr_flip"];
+      [library release];
+      if (!function) {
+          pipeline_error = [[NSError alloc]
+              initWithDomain:@"craftground"
+                         code:1
+                     userInfo:@{
+                         NSLocalizedDescriptionKey :
+                             @"Failed to load normalize_bgr_flip kernel"
+                     }];
+          return;
+      }
+
+      pipeline = [device newComputePipelineStateWithFunction:function
+                                                       error:&pipeline_error];
+      [function release];
+    });
+
+    if (!pipeline) {
+        std::string error_message = "Failed to build Metal normalize pipeline";
+        if (pipeline_error && pipeline_error.localizedDescription) {
+            error_message += ": ";
+            error_message += [pipeline_error.localizedDescription UTF8String];
+        }
+        throw std::runtime_error(error_message);
+    }
+
+    return pipeline;
+}
+
+at::Tensor normalizeAppleTensor(const at::Tensor &src) {
+    TORCH_CHECK(src.device().is_mps(), "Expected an MPS tensor");
+    TORCH_CHECK(src.scalar_type() == at::kByte, "Expected a uint8 tensor");
+    TORCH_CHECK(src.dim() == 3, "Expected an HWC tensor");
+    TORCH_CHECK(src.size(2) == 3, "Expected a 3-channel BGR tensor");
+    TORCH_CHECK(src.storage().data(), "Expected backing MTLBuffer storage");
+
+    at::Tensor dst = at::empty({src.size(0), src.size(1), 3}, src.options());
+
+    auto *stream = at::mps::getCurrentMPSStream();
+    id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+    id<MTLComputePipelineState> pipeline = getNormalizePipeline(stream->device());
+    id<MTLBuffer> src_buffer = (id<MTLBuffer>)src.storage().data();
+    id<MTLBuffer> dst_buffer = (id<MTLBuffer>)dst.storage().data();
+
+    NormalizeParams params{
+        static_cast<uint32_t>(src.size(1)),
+        static_cast<uint32_t>(src.size(0)),
+        static_cast<uint32_t>(src.stride(0)),
+        static_cast<uint32_t>(src.stride(1)),
+        static_cast<uint32_t>(src.storage_offset()),
+        static_cast<uint32_t>(dst.stride(0)),
+        static_cast<uint32_t>(dst.stride(1)),
+        static_cast<uint32_t>(dst.storage_offset()),
+    };
+
+    [encoder setComputePipelineState:pipeline];
+    [encoder setBuffer:src_buffer offset:0 atIndex:0];
+    [encoder setBuffer:dst_buffer offset:0 atIndex:1];
+    [encoder setBytes:&params length:sizeof(params) atIndex:2];
+
+    NSUInteger thread_width = pipeline.threadExecutionWidth;
+    NSUInteger thread_height = pipeline.maxTotalThreadsPerThreadgroup /
+        std::max<NSUInteger>(1, thread_width);
+    if (thread_height == 0) {
+        thread_height = 1;
+    }
+
+    MTLSize threads_per_threadgroup =
+        MTLSizeMake(thread_width, thread_height, 1);
+    MTLSize threads_per_grid = MTLSizeMake(
+        static_cast<NSUInteger>(src.size(1)),
+        static_cast<NSUInteger>(src.size(0)),
+        1
+    );
+    [encoder dispatchThreads:threads_per_grid
+      threadsPerThreadgroup:threads_per_threadgroup];
+
+    return dst;
+}
+
+} // namespace
+
+py::object normalize_apple_mtl_tensor_impl(py::object tensor) {
+    return py::cast(normalizeAppleTensor(tensor.cast<at::Tensor>()));
+}

--- a/src/cpp/ipc_apple_ops.mm
+++ b/src/cpp/ipc_apple_ops.mm
@@ -3,6 +3,7 @@
 #import <Metal/Metal.h>
 #include <pybind11/pybind11.h>
 #include <algorithm>
+#include <limits>
 
 namespace py = pybind11;
 
@@ -115,6 +116,14 @@ at::Tensor normalizeAppleTensor(const at::Tensor &src) {
     TORCH_CHECK(src.scalar_type() == at::kByte, "Expected a uint8 tensor");
     TORCH_CHECK(src.dim() == 3, "Expected an HWC tensor");
     TORCH_CHECK(src.size(2) == 3, "Expected a 3-channel BGR tensor");
+    TORCH_CHECK(
+        src.stride(2) == 1,
+        "Expected contiguous channel stride (stride(2) == 1)"
+    );
+    TORCH_CHECK(
+        src.stride(0) > 0 && src.stride(1) > 0,
+        "Expected positive row and pixel strides"
+    );
     TORCH_CHECK(src.storage().data(), "Expected backing MTLBuffer storage");
 
     at::Tensor dst = at::empty({src.size(0), src.size(1), 3}, src.options());
@@ -125,16 +134,26 @@ at::Tensor normalizeAppleTensor(const at::Tensor &src) {
         getNormalizePipeline(stream->device());
     id<MTLBuffer> src_buffer = (__bridge id<MTLBuffer>)src.storage().data();
     id<MTLBuffer> dst_buffer = (__bridge id<MTLBuffer>)dst.storage().data();
+    auto to_u32_checked = [](int64_t value, const char *name) -> uint32_t {
+        TORCH_CHECK(
+            value >= 0 &&
+                value <=
+                    static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+            name,
+            " is out of uint32 range for Metal kernel params"
+        );
+        return static_cast<uint32_t>(value);
+    };
 
     NormalizeParams params{
-        static_cast<uint32_t>(src.size(1)),
-        static_cast<uint32_t>(src.size(0)),
-        static_cast<uint32_t>(src.stride(0)),
-        static_cast<uint32_t>(src.stride(1)),
-        static_cast<uint32_t>(src.storage_offset()),
-        static_cast<uint32_t>(dst.stride(0)),
-        static_cast<uint32_t>(dst.stride(1)),
-        static_cast<uint32_t>(dst.storage_offset()),
+        to_u32_checked(src.size(1), "width"),
+        to_u32_checked(src.size(0), "height"),
+        to_u32_checked(src.stride(0), "src_row_stride"),
+        to_u32_checked(src.stride(1), "src_pixel_stride"),
+        to_u32_checked(src.storage_offset(), "src_offset"),
+        to_u32_checked(dst.stride(0), "dst_row_stride"),
+        to_u32_checked(dst.stride(1), "dst_pixel_stride"),
+        to_u32_checked(dst.storage_offset(), "dst_offset"),
     };
 
     [encoder setComputePipelineState:pipeline];

--- a/src/craftground/environment/observation_converter.py
+++ b/src/craftground/environment/observation_converter.py
@@ -68,6 +68,7 @@ class ObservationConverter:
         self.render_action = render_action
         self.render_mode = render_mode
         self.render_alternating_eyes = render_alternating_eyes
+        self._apple_normalize_tensor = None
         if output_type == ScreenEncodingMode.ZEROCOPY:
             try:
                 from .craftground_native import initialize_from_mach_port  # type: ignore
@@ -77,6 +78,11 @@ class ObservationConverter:
                     "To use zerocopy encoding mode, please install the craftground[cuda] package on linux or windows."
                     " If this error happens in macOS, please report it to the developers."
                 )
+            try:
+                from .craftground_native import normalize_apple_mtl_tensor  # type: ignore
+            except ImportError:
+                normalize_apple_mtl_tensor = None
+            self._apple_normalize_tensor = normalize_apple_mtl_tensor
         if output_type == ScreenEncodingMode.JAX:
             try:
                 import jax  # type: ignore
@@ -234,6 +240,8 @@ class ObservationConverter:
     def _normalize_apple_zerocopy_tensor(
         self, raw_tensor: "TorchArrayType"
     ) -> "TorchArrayType":
+        if self._apple_normalize_tensor is not None:
+            return self._apple_normalize_tensor(raw_tensor)
         return raw_tensor.clone()[:, :, [2, 1, 0]].flip(0)
 
     def _normalize_cuda_zerocopy_tensor(
@@ -242,7 +250,6 @@ class ObservationConverter:
         return raw_tensor.clone()[:, :, :3].flip(0)
 
     def initialize_zerocopy(self, ipc_handle: bytes):
-        import torch
         from .craftground_native import initialize_from_mach_port  # type: ignore
         from .craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
 
@@ -258,9 +265,6 @@ class ObservationConverter:
                 raise ValueError(f"Failed to initialize from mach port {mach_port}.")
             # image_tensor = torch.utils.dlpack.from_dlpack(apple_dl_tensor)
             rgb_array_or_tensor = apple_dl_tensor
-            print(rgb_array_or_tensor.shape)
-            print(rgb_array_or_tensor.dtype)
-            print(rgb_array_or_tensor.device)
             self.last_observations[0] = rgb_array_or_tensor
             self.internal_type = ObservationTensorType.APPLE_TENSOR
         else:
@@ -274,10 +278,6 @@ class ObservationConverter:
             if not cuda_dl_tensor:
                 raise ValueError("Invalid DLPack capsule: None")
             rgb_array_or_tensor = torch.utils.dlpack.from_dlpack(cuda_dl_tensor)
-            print(rgb_array_or_tensor.shape)
-            print(rgb_array_or_tensor.dtype)
-            print(rgb_array_or_tensor.device)
-            print(f"{rgb_array_or_tensor.data_ptr()=}\n\n")
             self.last_observations[0] = rgb_array_or_tensor
             self.internal_type = ObservationTensorType.CUDA_DLPACK
 

--- a/src/craftground/environment/observation_converter.py
+++ b/src/craftground/environment/observation_converter.py
@@ -134,9 +134,7 @@ class ObservationConverter:
                 raise ValueError("JAX mode does not support binocular vision")
             if self.internal_type == ObservationTensorType.JAX_NP:
                 return (self.last_observations[0], None)
-            else:
-                pass
-            return self.convert_jax_zerocopy(observation)
+            return (self.convert_jax_observation(observation.ipc_handle), None)
         else:
             raise ValueError(f"Unknown output type: {self.output_type}")
 
@@ -249,6 +247,20 @@ class ObservationConverter:
     ) -> "TorchArrayType":
         return raw_tensor.clone()[:, :, :3].flip(0)
 
+    def _normalize_jax_apple_zerocopy_tensor(
+        self, raw_tensor: "JaxArrayType"
+    ) -> "JaxArrayType":
+        import jax.numpy as jnp
+
+        return jnp.flip(raw_tensor[:, :, [2, 1, 0]], axis=0)
+
+    def _normalize_jax_cuda_zerocopy_tensor(
+        self, raw_tensor: "JaxArrayType"
+    ) -> "JaxArrayType":
+        import jax.numpy as jnp
+
+        return jnp.flip(raw_tensor[:, :, :3], axis=0)
+
     def initialize_zerocopy(self, ipc_handle: bytes):
         from .craftground_native import initialize_from_mach_port  # type: ignore
         from .craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
@@ -297,14 +309,8 @@ class ObservationConverter:
             if not dlpack_capsule:
                 raise ValueError(f"Failed to initialize from mach port {ipc_handle}.")
             jax_image = jnp.from_dlpack(dlpack_capsule)
-            # image_tensor = torch.utils.dlpack.from_dlpack(apple_dl_tensor)
-            rgb_array_or_tensor = jax_image
-            print(rgb_array_or_tensor.shape)
-            print(rgb_array_or_tensor.dtype)
-            print(rgb_array_or_tensor.device())
+            rgb_array_or_tensor = self._normalize_jax_apple_zerocopy_tensor(jax_image)
             self.last_observations[0] = rgb_array_or_tensor
-            # drop alpha, flip y axis, and clone
-            rgb_array_or_tensor = rgb_array_or_tensor.clone()[:, :, [2, 1, 0]].flip(0)
             self.internal_type = ObservationTensorType.JAX_NP
             return rgb_array_or_tensor
         else:
@@ -316,7 +322,7 @@ class ObservationConverter:
             if not cuda_dlpack:
                 raise ValueError("Invalid DLPack capsule: None")
             jax_image = jnp.from_dlpack(cuda_dlpack)
-            rgb_array_or_tensor = jax_image
-            rgb_array_or_tensor = rgb_array_or_tensor.clone()[:, :, [2, 1, 0]].flip(0)
+            rgb_array_or_tensor = self._normalize_jax_cuda_zerocopy_tensor(jax_image)
+            self.last_observations[0] = rgb_array_or_tensor
             self.internal_type = ObservationTensorType.JAX_NP
-            return jax_image, None
+            return rgb_array_or_tensor

--- a/src/craftground/environment/observation_converter.py
+++ b/src/craftground/environment/observation_converter.py
@@ -111,10 +111,12 @@ class ObservationConverter:
             if self.internal_type == ObservationTensorType.NONE:
                 self.initialize_zerocopy(observation.ipc_handle)
             if self.internal_type == ObservationTensorType.APPLE_TENSOR:
-                obs_1 = self.last_observations[0].clone()[:, :, [2, 1, 0]].flip(0)
+                obs_1 = self._normalize_apple_zerocopy_tensor(
+                    self.last_observations[0]
+                )
                 return (obs_1, None)
             elif self.internal_type == ObservationTensorType.CUDA_DLPACK:
-                obs_1 = self.last_observations[0].clone()[:, :, :3].flip(0)
+                obs_1 = self._normalize_cuda_zerocopy_tensor(self.last_observations[0])
                 return (obs_1, None)
             else:
                 raise ValueError(
@@ -229,6 +231,16 @@ class ObservationConverter:
             # arr = np.transpose(last_rgb_frame, (2, 1, 0))  # channels, width, height
         return rgb_array_or_tensor
 
+    def _normalize_apple_zerocopy_tensor(
+        self, raw_tensor: "TorchArrayType"
+    ) -> "TorchArrayType":
+        return raw_tensor.clone()[:, :, [2, 1, 0]].flip(0)
+
+    def _normalize_cuda_zerocopy_tensor(
+        self, raw_tensor: "TorchArrayType"
+    ) -> "TorchArrayType":
+        return raw_tensor.clone()[:, :, :3].flip(0)
+
     def initialize_zerocopy(self, ipc_handle: bytes):
         import torch
         from .craftground_native import initialize_from_mach_port  # type: ignore
@@ -250,8 +262,7 @@ class ObservationConverter:
             print(rgb_array_or_tensor.dtype)
             print(rgb_array_or_tensor.device)
             self.last_observations[0] = rgb_array_or_tensor
-            # drop alpha, flip y axis, and clone
-            self.observation_tensor_type = ObservationTensorType.APPLE_TENSOR
+            self.internal_type = ObservationTensorType.APPLE_TENSOR
         else:
             import torch.utils.dlpack
 
@@ -268,8 +279,7 @@ class ObservationConverter:
             print(rgb_array_or_tensor.device)
             print(f"{rgb_array_or_tensor.data_ptr()=}\n\n")
             self.last_observations[0] = rgb_array_or_tensor
-            # drop alpha, flip y axis, and clone
-            self.observation_tensor_type = ObservationTensorType.CUDA_DLPACK
+            self.internal_type = ObservationTensorType.CUDA_DLPACK
 
     def convert_jax_observation(self, ipc_handle: bytes) -> "JaxArrayType":
         import jax.numpy as jnp
@@ -295,7 +305,7 @@ class ObservationConverter:
             self.last_observations[0] = rgb_array_or_tensor
             # drop alpha, flip y axis, and clone
             rgb_array_or_tensor = rgb_array_or_tensor.clone()[:, :, [2, 1, 0]].flip(0)
-            self.observation_tensor_type = ObservationTensorType.JAX_NP
+            self.internal_type = ObservationTensorType.JAX_NP
             return rgb_array_or_tensor
         else:
             cuda_dlpack = mtl_tensor_from_cuda_mem_handle(
@@ -308,5 +318,5 @@ class ObservationConverter:
             jax_image = jnp.from_dlpack(cuda_dlpack)
             rgb_array_or_tensor = jax_image
             rgb_array_or_tensor = rgb_array_or_tensor.clone()[:, :, [2, 1, 0]].flip(0)
-            self.observation_tensor_type = ObservationTensorType.JAX_NP
+            self.internal_type = ObservationTensorType.JAX_NP
             return jax_image, None

--- a/tests/python/unit/test_observation_converter.py
+++ b/tests/python/unit/test_observation_converter.py
@@ -1,0 +1,54 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from craftground.environment.observation_converter import ObservationConverter
+from craftground.environment.observation_converter import ObservationTensorType
+from craftground.screen_encoding_modes import ScreenEncodingMode
+
+
+def test_macos_zerocopy_initializes_raw_tensor_and_returns_normalized_output():
+    raw_bgra = torch.tensor(
+        [
+            [[10, 20, 30, 255], [40, 50, 60, 255]],
+            [[70, 80, 90, 255], [100, 110, 120, 255]],
+        ],
+        dtype=torch.uint8,
+    )
+    fake_native = SimpleNamespace(
+        initialize_from_mach_port=lambda mach_port, width, height: raw_bgra,
+        mtl_tensor_from_cuda_mem_handle=lambda *args, **kwargs: None,
+    )
+    observation = SimpleNamespace(ipc_handle=(1234).to_bytes(4, byteorder="little"))
+    logger = MagicMock()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setitem(
+            sys.modules,
+            "craftground.environment.craftground_native",
+            fake_native,
+        )
+
+        converter = ObservationConverter(
+            output_type=ScreenEncodingMode.ZEROCOPY,
+            image_width=2,
+            image_height=2,
+            logger=logger,
+        )
+
+        obs, _ = converter.convert(observation)
+
+    expected = torch.tensor(
+        [
+            [[90, 80, 70], [120, 110, 100]],
+            [[30, 20, 10], [60, 50, 40]],
+        ],
+        dtype=torch.uint8,
+    )
+
+    assert converter.last_observations[0] is raw_bgra
+    assert converter.internal_type == ObservationTensorType.APPLE_TENSOR
+    assert torch.equal(obs, expected)

--- a/tests/python/unit/test_observation_converter.py
+++ b/tests/python/unit/test_observation_converter.py
@@ -11,15 +11,63 @@ from craftground.screen_encoding_modes import ScreenEncodingMode
 
 
 def test_macos_zerocopy_initializes_raw_tensor_and_returns_normalized_output():
-    raw_bgra = torch.tensor(
+    raw_bgr = torch.tensor(
         [
-            [[10, 20, 30, 255], [40, 50, 60, 255]],
-            [[70, 80, 90, 255], [100, 110, 120, 255]],
+            [[10, 20, 30], [40, 50, 60]],
+            [[70, 80, 90], [100, 110, 120]],
+        ],
+        dtype=torch.uint8,
+    )
+    normalized = torch.tensor(
+        [
+            [[90, 80, 70], [120, 110, 100]],
+            [[30, 20, 10], [60, 50, 40]],
+        ],
+        dtype=torch.uint8,
+    )
+    normalize_calls = []
+    fake_native = SimpleNamespace(
+        initialize_from_mach_port=lambda mach_port, width, height: raw_bgr,
+        mtl_tensor_from_cuda_mem_handle=lambda *args, **kwargs: None,
+        normalize_apple_mtl_tensor=lambda tensor: (
+            normalize_calls.append(tensor) or normalized
+        ),
+    )
+    observation = SimpleNamespace(ipc_handle=(1234).to_bytes(4, byteorder="little"))
+    logger = MagicMock()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setitem(
+            sys.modules,
+            "craftground.environment.craftground_native",
+            fake_native,
+        )
+
+        converter = ObservationConverter(
+            output_type=ScreenEncodingMode.ZEROCOPY,
+            image_width=2,
+            image_height=2,
+            logger=logger,
+        )
+
+        obs, _ = converter.convert(observation)
+
+    assert converter.last_observations[0] is raw_bgr
+    assert converter.internal_type == ObservationTensorType.APPLE_TENSOR
+    assert normalize_calls == [raw_bgr]
+    assert torch.equal(obs, normalized)
+
+
+def test_macos_zerocopy_falls_back_to_python_normalization_without_native_helper():
+    raw_bgr = torch.tensor(
+        [
+            [[10, 20, 30], [40, 50, 60]],
+            [[70, 80, 90], [100, 110, 120]],
         ],
         dtype=torch.uint8,
     )
     fake_native = SimpleNamespace(
-        initialize_from_mach_port=lambda mach_port, width, height: raw_bgra,
+        initialize_from_mach_port=lambda mach_port, width, height: raw_bgr,
         mtl_tensor_from_cuda_mem_handle=lambda *args, **kwargs: None,
     )
     observation = SimpleNamespace(ipc_handle=(1234).to_bytes(4, byteorder="little"))
@@ -49,6 +97,6 @@ def test_macos_zerocopy_initializes_raw_tensor_and_returns_normalized_output():
         dtype=torch.uint8,
     )
 
-    assert converter.last_observations[0] is raw_bgra
+    assert converter.last_observations[0] is raw_bgr
     assert converter.internal_type == ObservationTensorType.APPLE_TENSOR
     assert torch.equal(obs, expected)

--- a/tests/python/unit/test_observation_converter.py
+++ b/tests/python/unit/test_observation_converter.py
@@ -2,6 +2,7 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 import torch
 
@@ -100,3 +101,105 @@ def test_macos_zerocopy_falls_back_to_python_normalization_without_native_helper
     assert converter.last_observations[0] is raw_bgr
     assert converter.internal_type == ObservationTensorType.APPLE_TENSOR
     assert torch.equal(obs, expected)
+
+
+def test_jax_mach_port_returns_normalized_tensor_and_caches_it():
+    raw_bgra = np.array(
+        [
+            [[10, 20, 30, 255], [40, 50, 60, 255]],
+            [[70, 80, 90, 255], [100, 110, 120, 255]],
+        ],
+        dtype=np.uint8,
+    )
+    expected = np.array(
+        [
+            [[90, 80, 70], [120, 110, 100]],
+            [[30, 20, 10], [60, 50, 40]],
+        ],
+        dtype=np.uint8,
+    )
+    fake_jnp = SimpleNamespace(
+        from_dlpack=lambda capsule: raw_bgra.copy(),
+        flip=lambda array, axis: np.flip(array, axis=axis).copy(),
+    )
+    fake_native = SimpleNamespace(
+        mtl_dlpack_from_mach_port=lambda mach_port, width, height: object(),
+        mtl_tensor_from_cuda_mem_handle=lambda *args, **kwargs: None,
+    )
+    observation = SimpleNamespace(ipc_handle=(1234).to_bytes(4, byteorder="little"))
+    logger = MagicMock()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setitem(sys.modules, "jax", SimpleNamespace(numpy=fake_jnp))
+        monkeypatch.setitem(sys.modules, "jax.numpy", fake_jnp)
+        monkeypatch.setitem(
+            sys.modules,
+            "craftground.environment.craftground_native",
+            fake_native,
+        )
+
+        converter = ObservationConverter(
+            output_type=ScreenEncodingMode.JAX,
+            image_width=2,
+            image_height=2,
+            logger=logger,
+        )
+
+        first, _ = converter.convert(observation)
+        second, _ = converter.convert(observation)
+
+    assert converter.internal_type == ObservationTensorType.JAX_NP
+    assert np.array_equal(first, expected)
+    assert np.array_equal(second, expected)
+    assert np.array_equal(converter.last_observations[0], expected)
+
+
+def test_jax_cuda_handle_returns_normalized_tensor_and_caches_it():
+    raw_rgba = np.array(
+        [
+            [[1, 2, 3, 255], [4, 5, 6, 255]],
+            [[7, 8, 9, 255], [10, 11, 12, 255]],
+        ],
+        dtype=np.uint8,
+    )
+    expected = np.array(
+        [
+            [[7, 8, 9], [10, 11, 12]],
+            [[1, 2, 3], [4, 5, 6]],
+        ],
+        dtype=np.uint8,
+    )
+    fake_jnp = SimpleNamespace(
+        from_dlpack=lambda capsule: raw_rgba.copy(),
+        flip=lambda array, axis: np.flip(array, axis=axis).copy(),
+    )
+    fake_native = SimpleNamespace(
+        mtl_dlpack_from_mach_port=lambda *args, **kwargs: None,
+        mtl_tensor_from_cuda_mem_handle=lambda *args, **kwargs: object(),
+    )
+    observation = SimpleNamespace(ipc_handle=b"cuda-handle")
+    logger = MagicMock()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setitem(sys.modules, "jax", SimpleNamespace(numpy=fake_jnp))
+        monkeypatch.setitem(sys.modules, "jax.numpy", fake_jnp)
+        monkeypatch.setitem(
+            sys.modules,
+            "craftground.environment.craftground_native",
+            fake_native,
+        )
+
+        converter = ObservationConverter(
+            output_type=ScreenEncodingMode.JAX,
+            image_width=2,
+            image_height=2,
+            logger=logger,
+        )
+
+        first, _ = converter.convert(observation)
+        second, _ = converter.convert(observation)
+
+    assert converter.internal_type == ObservationTensorType.JAX_NP
+    assert np.array_equal(first, expected)
+    assert np.array_equal(second, expected)
+    assert np.array_equal(converter.last_observations[0], expected)


### PR DESCRIPTION
## Summary
- keep the macOS zerocopy transport tensor internal and stop exposing the clone workaround as the bridge contract
- replace the public `ZEROCOPY` path on macOS with a native Metal normalize op that writes an allocator-managed MPS tensor in `RGB + flipped` layout
- fix the Apple bridge tensor metadata to describe the underlying IOSurface correctly as a 3-channel BGR tensor with explicit row/pixel strides
- preserve the Python fallback normalization path when the native helper is unavailable
- add regression tests covering the native helper path and the Python fallback path

## Verification
- `uv run --extra test pytest tests/python/unit/test_observation_converter.py -v`
- `python -m pip install -e . --no-build-isolation`

## Notes
- a stable public raw zerocopy mode is intentionally not exposed yet because the upstream PyTorch MPS allocator contract for external buffers is still insufficient for view-safe raw tensor usage
- importing the built extension locally is still blocked by the existing `@rpath/libomp.dylib` runtime issue in this machine setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design spec and implementation plan for macOS zerocopy observation handling.

* **New Features**
  * macOS native-backed normalization to ensure consistent RGB + vertical-flip outputs.

* **Refactor**
  * Explicit separation between internal raw zerocopy tensor state and normalized public observation boundary.

* **Tests**
  * Unit tests validating zerocopy initialization, caching, internal type tracking, and consistent normalized outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->