### PR TITLE
ci: pin macOS runners to macos-15

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -23,7 +23,7 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
         build_type: [Release]
         c_compiler: [gcc, clang, cl]
         include:
@@ -36,10 +36,10 @@ jobs:
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
-          - os: macos-latest
+          - os: macos-15
             c_compiler: clang
             cpp_compiler: clang++
-          - os: macos-latest
+          - os: macos-15
             c_compiler: gcc
             cpp_compiler: g++
         exclude:
@@ -49,7 +49,7 @@ jobs:
             c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
-          - os: macos-latest
+          - os: macos-15
             c_compiler: cl
 
     steps:
@@ -58,7 +58,7 @@ jobs:
         submodules: true
 
     - name: install pytorch headers if macos # export CMAKE_PREFIX_PATH=$LIBTORCH
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-15'
       run: |
         curl -LO https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.5.1.zip
         unzip libtorch-macos-arm64-2.5.1.zip

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
         build_type: [Release]
         c_compiler: [gcc, clang, cl]
         include:
@@ -40,10 +40,10 @@ jobs:
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
-          - os: macos-latest
+          - os: macos-15
             c_compiler: clang
             cpp_compiler: clang++
-          - os: macos-latest
+          - os: macos-15
             c_compiler: gcc
             cpp_compiler: g++
         exclude:
@@ -53,7 +53,7 @@ jobs:
             c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
-          - os: macos-latest
+          - os: macos-15
             c_compiler: cl
     permissions:
       contents: read
@@ -67,7 +67,7 @@ jobs:
         distribution: 'temurin'
     
     - name: install pytorch headers if macos # export CMAKE_PREFIX_PATH=$LIBTORCH
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-15'
       run: |
         curl -LO https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.5.1.zip
         unzip libtorch-macos-arm64-2.5.1.zip

--- a/.github/workflows/publish-package-nocuda.yml
+++ b/.github/workflows/publish-package-nocuda.yml
@@ -17,8 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-latest, windows-latest] # macos-13, macos-14 makes corrupt zip
+        # macos-13 is an intel runner, macos-14 is apple silicon; macos-13/14 make corrupt zip.
+        # macos-15 pinned explicitly (not macos-latest): macos-latest is migrating to macos-26,
+        # whose Xcode/libc++ breaks the libtorch 2.5.1 build (is_arithmetic specialization error).
+        os: [ubuntu-latest, macos-15, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +36,7 @@ jobs:
     - uses: astral-sh/setup-uv@v4
 
     - name: Install python < 3.13 if macos # https://groups.google.com/g/vim_dev/c/1I20UCzmtF4
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-15'
       uses: actions/setup-python@v5
       with:
         python-version: '3.12' 


### PR DESCRIPTION
## Summary

`macos-latest` is migrating from macos-15 (Xcode 16.4) to macos-26 (Xcode 26.4.1), rolling out starting 2026-06-15. The newer Xcode/libc++ marks `std::is_arithmetic` with `_LIBCPP_NO_SPECIALIZATIONS`, which conflicts with libtorch 2.5.1's `c10/util/strong_type.h` specialization of that trait and breaks every macOS job that installs libtorch and compiles `shared/native-ipc/ipc_apple_torch.cpp`:

```
error: 'is_arithmetic' cannot be specialized: Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
```

This pins `macos-latest` → `macos-15` in `cmake-build.yml`, `gradle.yml`, and `publish-package-nocuda.yml`.

## Why macos-15 specifically

Verified locally by diffing the two Xcode Command Line Tools SDKs installed on this machine:

- `MacOSX15.4.sdk` (Xcode 16.4, current `macos-15` default) — `is_arithmetic` has no specialization restriction, builds clean.
- `MacOSX26.5.sdk` (Xcode 26.x, the `macos-26` default `macos-latest` is moving to) — `is_arithmetic` is marked `_LIBCPP_NO_SPECIALIZATIONS`, reproduces the exact CI failure.

`publish-package-nocuda.yml`'s existing comment (`macos-13, macos-14 makes corrupt zip`) only rules out 13/14, not 15, so this shouldn't reintroduce that older issue — worth confirming in CI regardless since it's a separate, previously-observed problem.

## Test plan

- [ ] CI on this PR — cmake-build, gradle, and wheel-build should now pass on macOS again