### PR TITLE
fix: ZEROCOPY-on-Apple import bug, state typo, and DLPack crash

### DIFF
--- a/shared/native-ipc/ipc_apple.mm
+++ b/shared/native-ipc/ipc_apple.mm
@@ -59,11 +59,13 @@ id<MTLTexture> createMetalTextureFromIOSurface(
 static void deleteDLManagedTensor(DLManagedTensor *self) {
     // CFRelease((__bridge CFTypeRef)self->dl_tensor.data);
     free(self->dl_tensor.shape);
+    free(self->dl_tensor.strides);
     free(self);
 }
 
-static DLManagedTensor *
-createDLPackTensorMetal(id<MTLBuffer> mtlBuffer, size_t width, size_t height) {
+static DLManagedTensor *createDLPackTensorMetal(
+    id<MTLBuffer> mtlBuffer, size_t width, size_t height, size_t bytesPerRow
+) {
     DLManagedTensor *tensor =
         (DLManagedTensor *)malloc(sizeof(DLManagedTensor));
 
@@ -73,7 +75,14 @@ createDLPackTensorMetal(id<MTLBuffer> mtlBuffer, size_t width, size_t height) {
     tensor->dl_tensor.shape[0] = height;
     tensor->dl_tensor.shape[1] = width;
     tensor->dl_tensor.shape[2] = 4; // RGBA
-    tensor->dl_tensor.strides = NULL;
+    // IOSurface can pad each row beyond width * bytesPerElement for GPU
+    // alignment, so strides must be explicit -- NULL implies tight packing
+    // derived from shape alone, which silently mismatches the real memory
+    // layout whenever bytesPerRow != width * 4.
+    tensor->dl_tensor.strides = (int64_t *)malloc(3 * sizeof(int64_t));
+    tensor->dl_tensor.strides[0] = (int64_t)bytesPerRow; // dtype is 1 byte
+    tensor->dl_tensor.strides[1] = 4;
+    tensor->dl_tensor.strides[2] = 1;
     tensor->dl_tensor.byte_offset = 0;
 
     tensor->dl_tensor.dtype =
@@ -137,7 +146,8 @@ mtl_tensor_from_mach_port(unsigned int machPort, int width, int height) {
         );
     }
 
-    DLManagedTensor *tensor = createDLPackTensorMetal(mtlBuffer, width, height);
+    DLManagedTensor *tensor =
+        createDLPackTensorMetal(mtlBuffer, width, height, bytesPerRow);
 
 #if USE_CUSTOM_DL_PACK_TENSOR
     return py::reinterpret_steal<py::object>(torchTensorFromDLPack(tensor));
@@ -146,9 +156,20 @@ mtl_tensor_from_mach_port(unsigned int machPort, int width, int height) {
         tensor,
         "dltensor",
         [](PyObject *capsule) {
+            // If a DLPack consumer already renamed the capsule to
+            // "used_dltensor", ownership (and the deleter call) was
+            // transferred to it -- calling the deleter again here would be a
+            // double-free. PyCapsule_GetPointer fails on a name mismatch and
+            // returns NULL, so without this check `tensor` would be NULL and
+            // the deleter call below would segfault.
+            if (!PyCapsule_IsValid(capsule, "dltensor")) {
+                return;
+            }
             DLManagedTensor *tensor =
                 (DLManagedTensor *)PyCapsule_GetPointer(capsule, "dltensor");
-            tensor->deleter(tensor);
+            if (tensor) {
+                tensor->deleter(tensor);
+            }
         }
     ));
 #endif

--- a/shared/native-ipc/ipc_apple.mm
+++ b/shared/native-ipc/ipc_apple.mm
@@ -60,7 +60,7 @@ static void deleteDLManagedTensor(DLManagedTensor *self) {
     // Balances the CFBridgingRetain(mtlBuffer) in createDLPackTensorMetal;
     // without this, every DLPack tensor leaked the retained MTLBuffer.
     if (self->dl_tensor.data) {
-        CFRelease((__bridge CFTypeRef)self->dl_tensor.data);
+        CFBridgingRelease(self->dl_tensor.data);
     }
     free(self->dl_tensor.shape);
     free(self->dl_tensor.strides);

--- a/shared/native-ipc/ipc_apple.mm
+++ b/shared/native-ipc/ipc_apple.mm
@@ -57,7 +57,11 @@ id<MTLTexture> createMetalTextureFromIOSurface(
 */
 
 static void deleteDLManagedTensor(DLManagedTensor *self) {
-    // CFRelease((__bridge CFTypeRef)self->dl_tensor.data);
+    // Balances the CFBridgingRetain(mtlBuffer) in createDLPackTensorMetal;
+    // without this, every DLPack tensor leaked the retained MTLBuffer.
+    if (self->dl_tensor.data) {
+        CFRelease((__bridge CFTypeRef)self->dl_tensor.data);
+    }
     free(self->dl_tensor.shape);
     free(self->dl_tensor.strides);
     free(self);

--- a/src/craftground/environment/observation_converter.py
+++ b/src/craftground/environment/observation_converter.py
@@ -70,8 +70,8 @@ class ObservationConverter:
         self.render_alternating_eyes = render_alternating_eyes
         if output_type == ScreenEncodingMode.ZEROCOPY:
             try:
-                from .craftground_native import initialize_from_mach_port  # type: ignore
-                from .craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
+                from ..craftground_native import initialize_from_mach_port  # type: ignore
+                from ..craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
             except ImportError:
                 raise ImportError(
                     "To use zerocopy encoding mode, please install the craftground[cuda] package on linux or windows."
@@ -231,8 +231,8 @@ class ObservationConverter:
 
     def initialize_zerocopy(self, ipc_handle: bytes):
         import torch
-        from .craftground_native import initialize_from_mach_port  # type: ignore
-        from .craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
+        from ..craftground_native import initialize_from_mach_port  # type: ignore
+        from ..craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
 
         if len(ipc_handle) == 0:
             raise ValueError("No ipc handle found.")
@@ -251,7 +251,7 @@ class ObservationConverter:
             print(rgb_array_or_tensor.device)
             self.last_observations[0] = rgb_array_or_tensor
             # drop alpha, flip y axis, and clone
-            self.observation_tensor_type = ObservationTensorType.APPLE_TENSOR
+            self.internal_type = ObservationTensorType.APPLE_TENSOR
         else:
             import torch.utils.dlpack
 
@@ -269,12 +269,12 @@ class ObservationConverter:
             print(f"{rgb_array_or_tensor.data_ptr()=}\n\n")
             self.last_observations[0] = rgb_array_or_tensor
             # drop alpha, flip y axis, and clone
-            self.observation_tensor_type = ObservationTensorType.CUDA_DLPACK
+            self.internal_type = ObservationTensorType.CUDA_DLPACK
 
     def convert_jax_observation(self, ipc_handle: bytes) -> "JaxArrayType":
         import jax.numpy as jnp
-        from .craftground_native import mtl_dlpack_from_mach_port  # type: ignore
-        from .craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
+        from ..craftground_native import mtl_dlpack_from_mach_port  # type: ignore
+        from ..craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
 
         if len(ipc_handle) == 0:
             raise ValueError("No ipc handle found.")
@@ -295,7 +295,7 @@ class ObservationConverter:
             self.last_observations[0] = rgb_array_or_tensor
             # drop alpha, flip y axis, and clone
             rgb_array_or_tensor = rgb_array_or_tensor.clone()[:, :, [2, 1, 0]].flip(0)
-            self.observation_tensor_type = ObservationTensorType.JAX_NP
+            self.internal_type = ObservationTensorType.JAX_NP
             return rgb_array_or_tensor
         else:
             cuda_dlpack = mtl_tensor_from_cuda_mem_handle(
@@ -308,5 +308,5 @@ class ObservationConverter:
             jax_image = jnp.from_dlpack(cuda_dlpack)
             rgb_array_or_tensor = jax_image
             rgb_array_or_tensor = rgb_array_or_tensor.clone()[:, :, [2, 1, 0]].flip(0)
-            self.observation_tensor_type = ObservationTensorType.JAX_NP
+            self.internal_type = ObservationTensorType.JAX_NP
             return jax_image, None


### PR DESCRIPTION
## Summary

Four bugs found while investigating a macOS `ScreenEncodingMode.ZEROCOPY` segfault, verified end-to-end against a real Metal/IOSurface capture (a live Minecraft render target's mach port, not a synthetic one).

1. **`observation_converter.py`: broken relative import.** `from .craftground_native import ...` inside `craftground/environment/observation_converter.py` resolves to `craftground.environment.craftground_native`, which has never existed — the compiled extension has always installed at `craftground.craftground_native` (top level). This has been broken since the `environment.py` → `environment/` package split (commit `9dd4992`, 2025-01-21) and is still broken on `main`/PyPI 2.6.15 today. Confirmed by downloading the actual last-working macOS wheel (2.5.37, back when `environment.py` was a flat module) and diffing against current source. Fixed: `from ..craftground_native import ...`.

   > **Note on [minecraft-simulator-benchmark](https://github.com/yhs0602/minecraft-simulator-benchmark):** this does **not** call that repo's published ZeroCopy results into question. Every dated ZeroCopy result in that repo's README (2025-01-07 through 2025-01-19) predates the 2025-01-21 refactor that introduced this bug — at the time those benchmarks ran, `environment.py` was still a flat module and the single-dot import was correct for that layout. The bug was introduced *after* those results were collected, not before, so the benchmark's credibility is unaffected; it simply means nobody has been able to run `ScreenEncodingMode.ZEROCOPY` since.

2. **`observation_converter.py`: state-attribute typo.** `initialize_zerocopy()` sets `self.observation_tensor_type`, but `convert()` branches on `self.internal_type` — a different, never-updated attribute. Fixing bug #1 alone surfaces this as `convert()` always raising `"Invalid internal type ... NONE"`. Unified on `self.internal_type`.

3. **`ipc_apple.mm` (`createDLPackTensorMetal`): missing stride.** `dl_tensor.strides` was left `NULL`, telling DLPack consumers the buffer is tightly packed per shape. `IOSurfaceGetBytesPerRow()` can pad rows beyond `width * bytesPerElement` for GPU alignment — e.g. width=114 pads 456→512 bytes/row, while width=64 or 640 happen to need no padding (confirmed by direct measurement) — silently corrupting captures at non-aligned widths. Now passes the real per-row stride through.

4. **`ipc_apple.mm` (`mtl_tensor_from_mach_port`, `USE_CUSTOM_DL_PACK_TENSOR=0` fallback): DLPack capsule double-free.** The `PyCapsule` destructor unconditionally called `tensor->deleter(tensor)` without checking whether a DLPack consumer had already renamed the capsule to `"used_dltensor"` (the standard DLPack ownership-transfer signal). `PyCapsule_GetPointer` fails on that name mismatch and returns `NULL`, so the deleter call was a NULL-pointer dereference. **This is the actual segfault**, reproduced end-to-end: `torch.utils.dlpack.from_dlpack()` on a real Metal capture crashed immediately after successful tensor creation, right at `initialize_zerocopy()`'s return (when the now-consumed capsule gets garbage collected). Fixed by checking `PyCapsule_IsValid()` first.

## What was and wasn't directly verified

This repo's default Apple build path (`USE_CUSTOM_DL_PACK_TENSOR=1`, via libtorch/`ipc_apple_torch.cpp`) could not be rebuilt on this machine to test end-to-end — same pre-existing Xcode/libc++ `is_arithmetic` incompatibility that the `macos-15` CI runner pin (#64) addresses. So:

- Bugs #1 and #2 are confirmed via git/PyPI archaeology (always broken, platform-independent) and were exercised end-to-end via bug #4's fix.
- Bugs #3 and #4 were found and fixed by testing the `USE_CUSTOM_DL_PACK_TENSOR=0` (raw DLPack capsule + `torch.utils.dlpack.from_dlpack`) fallback path locally, since the default libtorch path can't be compiled here. This fallback path shares the exact same `observation_converter.py` code and the exact same `IOSurfaceRef`/`MTLBuffer`/`createDLPackTensorMetal` capture logic as the default path — `createDLPackTensorMetal`'s stride fix directly affects both, and the capsule fix is scoped to the fallback branch only (currently dead code under the default `USE_CUSTOM_DL_PACK_TENSOR=1` config, fixed defensively).
- `shared/native-ipc/ipc_apple.mm` compiles cleanly with these changes (verified up to the point of the unrelated, pre-existing `ipc_apple_torch.cpp` failure).

A related pre-existing bug — `convert_jax_observation()` importing a `mtl_dlpack_from_mach_port` symbol that has never been bound in `ipc.cpp` — is **not** fixed here; it's untested and out of scope for this change.

## Test plan

- [x] Real end-to-end test: real Minecraft render target → mach port → `initialize_from_mach_port` → `torch.utils.dlpack.from_dlpack` → `.clone()[:, :, [2,1,0]].flip(0)`, `reset()` + 5×`step()`, all passing with live `mps:0` tensors (varying per-frame pixel means confirming real data) — before this fix: `ModuleNotFoundError` (bug #1) → after fixing #1: `ValueError` (bug #2) → after fixing #1+#2: `Fatal Python error: Segmentation fault` (bug #4) → after all four fixes: `ZEROCOPY SMOKE TEST PASSED`
- [x] `shared/native-ipc/ipc_apple.mm` compiles cleanly (CMake build reaches the unrelated `ipc_apple_torch.cpp` failure only)
- [ ] CI on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of GPU memory layouts when transferring observations, including support for row padding.
  * Prevented duplicate cleanup during certain tensor transfers.
  * Corrected native module loading in observation conversion.
  * Aligned internal observation type handling for more reliable conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
