### PR TITLE
fix: skip PyPy wheel builds in cibuildwheel

### DIFF
--- a/.github/workflows/publish-package-cuda-linux.yml
+++ b/.github/workflows/publish-package-cuda-linux.yml
@@ -54,7 +54,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.22.0
       env:
         CIBW_BUILD_VERBOSITY: 1
-        CIBW_SKIP: "cp36-* cp37-* cp38-* *musl*"
+        CIBW_SKIP: "cp36-* cp37-* cp38-* *musl* pp*"
         CIBW_ENABLE: cpython-prerelease
         CIBW_ARCHS_LINUX: "x86_64"
         CIBW_BEFORE_ALL: > # https://stackoverflow.com/a/77212119/8614565

--- a/.github/workflows/publish-package-cuda-windows.yml
+++ b/.github/workflows/publish-package-cuda-windows.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.22.0
       env:
-        CIBW_SKIP: cp36-* cp37-* cp38-*
+        CIBW_SKIP: cp36-* cp37-* cp38-* pp*
         CIBW_ENABLE: cpython-prerelease
         CIBW_ARCHS_WINDOWS: "AMD64"
         CIBW_ENVIRONMENT_WINDOWS: CUDA_TOOLKIT_ROOT_DIR=${{ env.CONDA }}/Library/lib LIB=${{ env.CONDA }}/Library/lib SKBUILD_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=${{ env.CONDA }}/Library/lib" CMAKE_ARGS="-DCMAKE_PREFIX_PATH=${{ env.CONDA }}/Library/lib"

--- a/.github/workflows/publish-package-nocuda.yml
+++ b/.github/workflows/publish-package-nocuda.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.22.0
       env:
-        CIBW_SKIP: cp36-* cp37-* cp38-* cp313-macosx_*
+        CIBW_SKIP: cp36-* cp37-* cp38-* cp313-macosx_* pp*
         CIBW_ARCHS_WINDOWS: "x86"
         CIBW_ARCHS_MACOS: "arm64"
         CIBW_ARCHS_LINUX: "i686"


### PR DESCRIPTION
pp37-win_amd64 and pp38-pypy38_pp73 CI builds failed: Windows lacks NMake/MSVC setup for PyPy, and the old manylinux i686 image ships a cmake wheel that can't load libatomic.so.1. This project's native CMake/pybind11 extension isn't PyPy-compatible in these environments.

# Pull ##

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/yhs0602/8497c0c395a8d6b18d1e81f05ff57dba/raw/craftground__pull_##.json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package build workflows to skip unsupported PyPy wheel targets across Linux, Windows, and macOS builds.
  * Existing CUDA setup, verification, caching, and artifact publishing steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->