### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/publish-package-cuda-linux.yml
+++ b/.github/workflows/publish-package-cuda-linux.yml
@@ -60,7 +60,7 @@ jobs:
         CIBW_BEFORE_ALL: > # https://stackoverflow.com/a/77212119/8614565
           yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo &&
           yum clean all &&
-          yum -y install cuda-toolkit &&
+          yum -y install cuda-nvcc-12-4 cuda-cudart-devel-12-4 &&
           ls -al /usr/local &&
           export PATH=$PATH:/usr/local/cuda/bin &&
           nvcc --version

--- a/.github/workflows/publish-package-nocuda.yml
+++ b/.github/workflows/publish-package-nocuda.yml
@@ -65,6 +65,7 @@ jobs:
         CIBW_ARCHS_MACOS: "arm64"
         CIBW_ARCHS_LINUX: "i686"
         CIBW_PROJECT_REQUIRES_PYTHON: "<=3.12"
+        CIBW_BEFORE_ALL_LINUX: yum install -y libatomic
         CIBW_BEFORE_ALL_MACOS: >
           curl -LO https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.5.1.zip &&
           unzip -q libtorch-macos-arm64-2.5.1.zip &&


### PR DESCRIPTION
# Pull ##

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/yhs0602/8497c0c395a8d6b18d1e81f05ff57dba/raw/craftground__pull_##.json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux CUDA package builds to use specific CUDA 12.4 development components.
  * Added the required `libatomic` system dependency to Linux builds without CUDA.
  * No changes to public APIs or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->