### PR TITLE
fix: bundle minecraft/mc121 into the wheel again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,31 @@ target_compile_definitions(
 
 install(TARGETS craftground_native LIBRARY DESTINATION craftground)
 
+# The Fabric mod project (minecraft/mc121) is the Gradle project that
+# `CraftGroundEnvironment.start_server()` runs at runtime (`./gradlew
+# runClient`). It lives outside src/craftground so it isn't picked up
+# automatically by scikit-build-core's Python source packaging, so it has to
+# be installed into the wheel explicitly. Only the tracked project sources
+# are copied - local Gradle/CMake build output must never end up in the
+# wheel.
+install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/minecraft/mc121/
+    DESTINATION craftground/minecraft/mc121
+    USE_SOURCE_PERMISSIONS
+    PATTERN "build" EXCLUDE
+    PATTERN "run" EXCLUDE
+    PATTERN "_deps" EXCLUDE
+    PATTERN ".gradle" EXCLUDE
+    PATTERN "CMakeFiles" EXCLUDE
+    PATTERN "CMakeCache.txt" EXCLUDE
+    PATTERN "cmake_install.cmake" EXCLUDE
+    PATTERN "compile_commands.json" EXCLUDE
+    PATTERN "Makefile" EXCLUDE
+    PATTERN "*.so" EXCLUDE
+    PATTERN "*.dylib" EXCLUDE
+    PATTERN "*.dll" EXCLUDE
+)
+
 option(BUILD_TESTS "Build tests" OFF)
 if(BUILD_TESTS)
     enable_testing()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ["minecraft", "reinforcement learning", "environment"]
 license = {file = "LICENSE"}
 name = "craftground"
 readme = "README.md"
-version = "2.6.23"
+version = "2.6.24"
 
 dependencies = [
   "gymnasium",

--- a/src/craftground/environment/environment.py
+++ b/src/craftground/environment/environment.py
@@ -104,10 +104,10 @@ class CraftGroundEnvironment(gym.Env):
         self.process = None
         self.use_shared_memory = use_shared_memory
         if env_path is None:
-            repo_root = os.path.dirname(
-                os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+            package_dir = os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__))
             )
-            self.env_path = os.path.join(repo_root, "minecraft", "mc121")
+            self.env_path = os.path.join(package_dir, "minecraft", "mc121")
         else:
             self.env_path = env_path
             gradle_path = shutil.which("gradlew", path=self.env_path)
@@ -461,8 +461,8 @@ class CraftGroundEnvironment(gym.Env):
     def get_env_base_path() -> str:
         current_file = os.path.abspath(__file__)
         current_dir = os.path.dirname(current_file)
-        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(current_dir)))
-        env_dir = os.path.join(repo_root, "minecraft", "mc121", "run")
+        package_dir = os.path.dirname(current_dir)
+        env_dir = os.path.join(package_dir, "minecraft", "mc121", "run")
         return env_dir
 
     @staticmethod


### PR DESCRIPTION
## Summary

`craftground==2.6.23` pip-installs cleanly but `env.reset()` fails immediately:

```
FileNotFoundError: [Errno 2] No such file or directory:
'.../minecraft/mc121/gradlew'
```

Found while installing 2.6.23 into `minecraft-simulator-benchmark` for a post-release smoke test.

Root cause: the Phase 1 restructure (7336d83, part of the 26.2 migration prep) moved the Fabric mod project from `src/craftground/MinecraftEnv` to top-level `minecraft/mc121`. Before that move it lived inside the `craftground` package, so scikit-build-core's default Python source packaging shipped it in the wheel for free. After the move it sits outside `src/`, so nothing installs it into the wheel anymore — `craftground.make()` can't launch Minecraft for any pip-installed user.

- `CMakeLists.txt`: explicitly install the tracked `minecraft/mc121` sources into `craftground/minecraft/mc121` in the wheel, excluding local Gradle/CMake build output (`build/`, `_deps/`, `run/`, `CMakeCache.txt`, etc.)
- `environment.py`: fix `env_path`/`get_env_base_path` default resolution to look inside the installed package (`<package>/minecraft/mc121`) instead of 4 `dirname()`s up from `environment.py`, which no longer lands anywhere meaningful once installed
- bump version to 2.6.24

## Verification

Couldn't build a full wheel locally end-to-end — hit a pre-existing, unrelated libtorch/Xcode toolchain break (`is_arithmetic` specialization error), already called out in `publish-package-nocuda.yml`'s `macos-15` pin comment, and reproduces identically on `main` before this change.

Instead verified the packaging logic directly:
- Ran the new `install(DIRECTORY ...)` rule standalone against `minecraft/mc121` — output matches `git ls-files minecraft/mc121` exactly (2.1M, no `build/`/`_deps/`/`run/` leakage), `gradlew` keeps its executable bit.
- Confirmed the new `env_path` resolution computed from a fake installed-package layout lands exactly on that installed `gradlew`.

## Test plan

- [ ] CI wheel build succeeds on macos-15 (this repo's pinned runner, avoids the unrelated toolchain issue hit locally)
- [ ] `pip install craftground==2.6.24` then `craftground.make(...); env.reset()` succeeds without `FileNotFoundError`
- [ ] Spot check the installed wheel contains `craftground/minecraft/mc121/gradlew` and no `build/`/`_deps/` bloat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python packages now include the required Minecraft project files for more complete installations.
* **Bug Fixes**
  * Improved environment path resolution so packaged installations can locate Minecraft resources more reliably.
* **Chores**
  * Updated the package version to 2.6.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->