### PR TITLE
feat: split minecraft/mc121 and mc262 into separate PyPI runtime packages

### DIFF
--- a/.github/workflows/publish-build-runtime-packages.yml
+++ b/.github/workflows/publish-build-runtime-packages.yml
@@ -1,0 +1,36 @@
+name: Runtime packages
+
+on: [workflow_call]
+
+env:
+  FORCE_COLOR: 3
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-runtime-packages
+  cancel-in-progress: true
+
+jobs:
+  build_runtime_packages:
+    name: Build ${{ matrix.mc_dir }} runtime package
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mc_dir: [minecraft/mc121, minecraft/mc262]
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+
+    - name: Build sdist and wheel
+      run: pipx run build --outdir ${{ github.workspace }}/dist
+      working-directory: ${{ matrix.mc_dir }}
+
+    - name: Check metadata
+      run: pipx run twine check dist/*
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: cibw-runtime-${{ matrix.mc_dir == 'minecraft/mc121' && 'mc121' || 'mc262' }}
+        path: dist/*

--- a/.github/workflows/publish-upload.yml
+++ b/.github/workflows/publish-upload.yml
@@ -25,9 +25,11 @@ jobs:
     uses: ./.github/workflows/publish-package-nocuda.yml
   build_sdist:
     uses: ./.github/workflows/publish-build-sdist.yml
+  build_runtime_packages:
+    uses: ./.github/workflows/publish-build-runtime-packages.yml
   upload_all:
     name: Upload if release
-    needs: [build_cuda_wheels_linux, build_cuda_wheels_windows, build_nocuda_wheels, build_sdist]
+    needs: [build_cuda_wheels_linux, build_cuda_wheels_windows, build_nocuda_wheels, build_sdist, build_runtime_packages]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     environment: pypi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,30 +150,12 @@ target_compile_definitions(
 
 install(TARGETS craftground_native LIBRARY DESTINATION craftground)
 
-# The Fabric mod project (minecraft/mc121) is the Gradle project that
-# `CraftGroundEnvironment.start_server()` runs at runtime (`./gradlew
-# runClient`). It lives outside src/craftground so it isn't picked up
-# automatically by scikit-build-core's Python source packaging, so it has to
-# be installed into the wheel explicitly. Only the tracked project sources
-# are copied - local Gradle/CMake build output must never end up in the
-# wheel.
-install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/minecraft/mc121/
-    DESTINATION craftground/minecraft/mc121
-    USE_SOURCE_PERMISSIONS
-    PATTERN "build" EXCLUDE
-    PATTERN "run" EXCLUDE
-    PATTERN "_deps" EXCLUDE
-    PATTERN ".gradle" EXCLUDE
-    PATTERN "CMakeFiles" EXCLUDE
-    PATTERN "CMakeCache.txt" EXCLUDE
-    PATTERN "cmake_install.cmake" EXCLUDE
-    PATTERN "compile_commands.json" EXCLUDE
-    PATTERN "Makefile" EXCLUDE
-    PATTERN "*.so" EXCLUDE
-    PATTERN "*.dylib" EXCLUDE
-    PATTERN "*.dll" EXCLUDE
-)
+# The Fabric mod projects (minecraft/mc121, minecraft/mc262) are no longer
+# bundled into this wheel - each ships as its own `craftground-runtime-mcXXX`
+# package (see minecraft/mc121/pyproject.toml, minecraft/mc262/pyproject.toml)
+# so that adding/updating a Minecraft version doesn't require rebuilding this
+# native wheel. `CraftGroundEnvironment` locates the installed runtime package
+# at runtime via `resolve_runtime_env_path()`.
 
 option(BUILD_TESTS "Build tests" OFF)
 if(BUILD_TESTS)

--- a/minecraft/mc121/.gitignore
+++ b/minecraft/mc121/.gitignore
@@ -102,6 +102,8 @@ $RECYCLE.BIN/
 
 .gradle
 build/
+dist/
+*.egg-info/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/minecraft/mc121/MANIFEST.in
+++ b/minecraft/mc121/MANIFEST.in
@@ -1,0 +1,20 @@
+recursive-include . *
+prune build
+prune dist
+prune run
+prune _deps
+prune .gradle
+prune CMakeFiles
+prune craftground_runtime_mc121.egg-info
+exclude CMakeCache.txt
+exclude cmake_install.cmake
+exclude compile_commands.json
+exclude Makefile
+exclude pyproject.toml
+exclude MANIFEST.in
+exclude .gitignore
+global-exclude *.so
+global-exclude *.dylib
+global-exclude *.dll
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/minecraft/mc121/__init__.py
+++ b/minecraft/mc121/__init__.py
@@ -1,0 +1,1 @@
+"""CraftGround runtime assets for Minecraft 1.21 (Fabric mod source + Gradle project)."""

--- a/minecraft/mc121/pyproject.toml
+++ b/minecraft/mc121/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61"]
+
+[project]
+name = "craftground-runtime-mc121"
+version = "0.1.0"
+description = "CraftGround Fabric mod runtime assets for Minecraft 1.21"
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+
+[project.urls]
+Source = "https://github.com/yhs0602/CraftGround"
+
+[tool.setuptools]
+packages = ["craftground_runtime_mc121"]
+include-package-data = true
+
+[tool.setuptools.package-dir]
+craftground_runtime_mc121 = "."
+
+[tool.setuptools.exclude-package-data]
+craftground_runtime_mc121 = [
+  "build",
+  "build/**",
+  "dist",
+  "dist/**",
+  "*.egg-info",
+  "*.egg-info/**",
+  "pyproject.toml",
+  "MANIFEST.in",
+  "setup.cfg",
+  ".gitignore",
+]

--- a/minecraft/mc262/.gitignore
+++ b/minecraft/mc262/.gitignore
@@ -102,6 +102,8 @@ $RECYCLE.BIN/
 
 .gradle
 build/
+dist/
+*.egg-info/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/minecraft/mc262/MANIFEST.in
+++ b/minecraft/mc262/MANIFEST.in
@@ -1,0 +1,20 @@
+recursive-include . *
+prune build
+prune dist
+prune run
+prune _deps
+prune .gradle
+prune CMakeFiles
+prune craftground_runtime_mc262.egg-info
+exclude CMakeCache.txt
+exclude cmake_install.cmake
+exclude compile_commands.json
+exclude Makefile
+exclude pyproject.toml
+exclude MANIFEST.in
+exclude .gitignore
+global-exclude *.so
+global-exclude *.dylib
+global-exclude *.dll
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/minecraft/mc262/__init__.py
+++ b/minecraft/mc262/__init__.py
@@ -1,0 +1,1 @@
+"""CraftGround runtime assets for Minecraft 26.2 (Fabric mod source + Gradle project)."""

--- a/minecraft/mc262/pyproject.toml
+++ b/minecraft/mc262/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61"]
+
+[project]
+name = "craftground-runtime-mc262"
+version = "0.1.0"
+description = "CraftGround Fabric mod runtime assets for Minecraft 26.2"
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+
+[project.urls]
+Source = "https://github.com/yhs0602/CraftGround"
+
+[tool.setuptools]
+packages = ["craftground_runtime_mc262"]
+include-package-data = true
+
+[tool.setuptools.package-dir]
+craftground_runtime_mc262 = "."
+
+[tool.setuptools.exclude-package-data]
+craftground_runtime_mc262 = [
+  "build",
+  "build/**",
+  "dist",
+  "dist/**",
+  "*.egg-info",
+  "*.egg-info/**",
+  "pyproject.toml",
+  "MANIFEST.in",
+  "setup.cfg",
+  ".gitignore",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,14 @@ dependencies = [
   "typing_extensions",
   "psutil",
   "torch",
+  "craftground-runtime-mc121",
 ]
 
 [project.optional-dependencies]
+mc262 = [
+  "craftground-runtime-mc262",
+]
+
 test = [
   "flake8",
   "pytest",
@@ -58,7 +63,7 @@ repair-wheel-command = "" # Disable repair wheel command on macOS
 
 [tool.scikit-build]
 wheel.expand-macos-universal-tags = true
-sdist.exclude = ["docs", "figures", "paper", "poster", "/tools", ".github", ".idea", ".vscode"]
+sdist.exclude = ["docs", "figures", "paper", "poster", "/tools", ".github", ".idea", ".vscode", "minecraft/mc121", "minecraft/mc262"]
 
 [tool.black]
 extend-exclude = '''

--- a/src/craftground/environment/environment.py
+++ b/src/craftground/environment/environment.py
@@ -23,6 +23,7 @@ from .action_space import (
 )
 from .observation_converter import ObservationConverter
 from .observation_space import declare_observation_space
+from .runtime_packages import resolve_runtime_env_path
 from .socket_ipc import SocketIPC
 
 from ..csv_logger import CsvLogger, LogBackend
@@ -51,6 +52,7 @@ class CraftGroundEnvironment(gym.Env):
         action_space_version: ActionSpaceVersion = ActionSpaceVersion.V1_MINEDOJO,
         verbose=False,
         env_path=None,
+        mc_version: str = "1.21",  # "26.2" builds but has no mixins/frame capture yet - non-functional
         port=8000,
         find_free_port: bool = True,
         use_shared_memory: bool = False,
@@ -104,10 +106,7 @@ class CraftGroundEnvironment(gym.Env):
         self.process = None
         self.use_shared_memory = use_shared_memory
         if env_path is None:
-            package_dir = os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))
-            )
-            self.env_path = os.path.join(package_dir, "minecraft", "mc121")
+            self.env_path = resolve_runtime_env_path(mc_version)
         else:
             self.env_path = env_path
             gradle_path = shutil.which("gradlew", path=self.env_path)

--- a/src/craftground/environment/runtime_packages.py
+++ b/src/craftground/environment/runtime_packages.py
@@ -1,0 +1,26 @@
+import importlib.resources
+
+# Maps the public `mc_version` string to the installed runtime package that
+# ships the corresponding Fabric mod's Gradle project (see
+# minecraft/mc121/pyproject.toml, minecraft/mc262/pyproject.toml).
+_RUNTIME_PACKAGES = {
+    "1.21": "craftground_runtime_mc121",
+    "26.2": "craftground_runtime_mc262",
+}
+
+
+def resolve_runtime_env_path(mc_version: str) -> str:
+    package_name = _RUNTIME_PACKAGES.get(mc_version)
+    if package_name is None:
+        raise ValueError(
+            f"Unsupported mc_version: {mc_version!r}. "
+            f"Supported: {sorted(_RUNTIME_PACKAGES)}"
+        )
+    try:
+        return str(importlib.resources.files(package_name))
+    except ModuleNotFoundError as e:
+        dist_name = package_name.replace("_", "-")
+        raise ModuleNotFoundError(
+            f"{dist_name} is not installed. Run `pip install {dist_name}` "
+            f"(or the matching `craftground[...]` extra) to use mc_version={mc_version!r}."
+        ) from e


### PR DESCRIPTION
## Summary
- `minecraft/mc121/` and `minecraft/mc262/` are now each their own installable, pure-Python (`py3-none-any`) package — `craftground-runtime-mc121` / `craftground-runtime-mc262` — shipping the same Gradle project source that `CraftGroundEnvironment` already runs `./gradlew runClient` against. No change to the runtime execution model itself.
- Core `craftground`'s `CMakeLists.txt` no longer bundles `minecraft/mc121` into its own wheel; that responsibility moves to the new runtime packages.
- `pyproject.toml`: `craftground-runtime-mc121` added as a normal dependency (so plain `pip install craftground` behaves exactly as before), `craftground-runtime-mc262` added as the `mc262` extra (`pip install "craftground[mc262]"`). `minecraft/mc121`/`mc262` added to `sdist.exclude` since they now belong to their own distributions.
- `CraftGroundEnvironment` gains a `mc_version: str = "1.21"` parameter; a new `resolve_runtime_env_path()` helper (`src/craftground/environment/runtime_packages.py`) looks up the installed runtime package via `importlib.resources`, raising a `ModuleNotFoundError` with the right `pip install` command if it's missing.
- New CI workflow `publish-build-runtime-packages.yml` builds+checks both runtime wheels and feeds them into the existing `upload_all` job via the `cibw-*` artifact naming convention (no changes needed downstream).

Base branch is `feature/mc262-gradle-scaffold` (#69) since this depends on `minecraft/mc262/` existing; will retarget to `main` once that merges.

## Test plan
- [x] Built both runtime wheels in isolated copies of `minecraft/mc121`/`mc262`, confirmed `gradlew`, `build.gradle`, `src/**` present and `build/`, `.gradle/`, `*.egg-info`, `pyproject.toml`, `MANIFEST.in` correctly excluded
- [x] Installed both wheels into a venv and confirmed `importlib.resources.files(...)` resolves to a directory containing a working `gradlew`
- [x] Exercised `resolve_runtime_env_path("1.21")`, `("26.2")`, unsupported version (`ValueError`), and missing-package (`ModuleNotFoundError`) cases directly
- [x] `python -m py_compile` on the modified/new Python files
- [x] YAML/TOML syntax validated on all touched workflow/pyproject files
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)