### PR TITLE
fix: install craftground-runtime-mc121 from source in CI until it's on PyPI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -28,6 +28,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        # craftground-runtime-mc121 isn't published on PyPI yet, so install it
+        # from the local Gradle project instead of letting `.[test]` resolve
+        # it remotely (see minecraft/mc121/pyproject.toml).
+        python -m pip install ./minecraft/mc121
         python -m pip install .[test]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ["minecraft", "reinforcement learning", "environment"]
 license = {file = "LICENSE"}
 name = "craftground"
 readme = "README.md"
-version = "2.6.24"
+version = "2.7.1"
 
 dependencies = [
   "gymnasium",


### PR DESCRIPTION
## Summary
Fixes the `Python package` CI failure on `main` introduced by #70: `craftground` now depends on `craftground-runtime-mc121`, which hasn't been published to PyPI yet, so `pip install .[test]` fails with `No matching distribution found for craftground-runtime-mc121`.

- Installs `./minecraft/mc121` (which has its own `pyproject.toml`, see #70) before `pip install .[test]` in the `test` job's dependency step, so CI doesn't depend on a PyPI release that doesn't exist yet.

**Follow-up needed**: `craftground-runtime-mc121` (and `craftground-runtime-mc262`) still need to actually be published to PyPI as their own projects before an end user's plain `pip install craftground` will work — that requires one-time PyPI project/trusted-publisher setup that only the account owner can do. Flagging this so it doesn't get lost.

## Test plan
- [x] YAML syntax validated
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test setup to install the local Minecraft 1.21 package before running tests.
  * Improved CI reliability by avoiding remote dependency resolution for this package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->