### PR TITLE
Feat/mc262 scaffolding

### DIFF
--- a/ARCHITECTURE_FLOWCHART.md
+++ b/ARCHITECTURE_FLOWCHART.md
@@ -365,7 +365,7 @@ graph TB
     
     C --> C1[imageSizeX: int]
     C --> C2[imageSizeY: int]
-    C --> C3[screen_encoding_mode:<br/>PNG/RAW/ZEROCOPY/JAX]
+    C --> C3[screen_encoding_mode:<br/>PNG/RAW/ZEROCOPY_TORCH/ZEROCOPY_JAX]
     C --> C4[eye_distance: float<br/>Binocular mode]
     
     D --> D1[spawnX, Y, Z: float]

--- a/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/EnvironmentInitializer.kt
+++ b/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/EnvironmentInitializer.kt
@@ -7,6 +7,7 @@ import com.kyhsgeekcode.minecraftenv.proto.InitialEnvironment.InitialEnvironment
 import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gui.Element
 import net.minecraft.client.gui.hud.ChatHud
+import net.minecraft.client.gui.screen.AccessibilityOnboardingScreen
 import net.minecraft.client.gui.screen.MessageScreen
 import net.minecraft.client.gui.screen.TitleScreen
 import net.minecraft.client.gui.screen.world.CreateWorldScreen
@@ -72,6 +73,16 @@ class EnvironmentInitializer(
         }
         csvLogger.profileStartPrint("Minecraft_env/onInitialize/ClientTick/EnvironmentInitializer/onClientTick")
         disableNarrator(client)
+        val currentScreenBeforeEnteringWorld = client.currentScreen
+        if (currentScreenBeforeEnteringWorld is AccessibilityOnboardingScreen) {
+            // Fresh options.txt files make vanilla show this screen before the title
+            // screen. Our GUI-driving logic below doesn't know this screen, so left
+            // unhandled it blocks startup forever. Dismiss it the same way Escape/Done
+            // would, which also persists onboardAccessibility=false so it won't reappear.
+            currentScreenBeforeEnteringWorld.close()
+            csvLogger.profileEndPrint("Minecraft_env/onInitialize/ClientTick/EnvironmentInitializer/onClientTick")
+            return
+        }
         if (!initialEnvironment.levelDisplayNameToPlay.isNullOrEmpty()) {
             enterExistingWorldUsingGUI(client, initialEnvironment.levelDisplayNameToPlay)
         } else {

--- a/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
+++ b/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
@@ -148,6 +148,7 @@ object FramebufferCapturer {
 
     const val RAW = 0
     const val PNG = 1
+
     // Both share the mach-port/CUDA-handle capture path below; they only differ
     // in which array type Python wraps the shared GPU buffer as.
     const val ZEROCOPY_TORCH = 2

--- a/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
+++ b/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
@@ -25,7 +25,7 @@ object FramebufferCapturer {
         xPos: Int,
         yPos: Int,
     ): ByteString {
-        if (encodingMode == ZEROCOPY) {
+        if (encodingMode == ZEROCOPY_TORCH || encodingMode == ZEROCOPY_JAX) {
             assert(textureWidth == targetSizeX && textureHeight == targetSizeY)
             return captureFramebufferZerocopyImpl(
                 frameBufferId,
@@ -148,7 +148,10 @@ object FramebufferCapturer {
 
     const val RAW = 0
     const val PNG = 1
-    const val ZEROCOPY = 2
+    // Both share the mach-port/CUDA-handle capture path below; they only differ
+    // in which array type Python wraps the shared GPU buffer as.
+    const val ZEROCOPY_TORCH = 2
+    const val ZEROCOPY_JAX = 3
 
     var isExtensionAvailable: Boolean = false
     private var hasCheckedExtension: Boolean = false

--- a/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -1072,6 +1072,7 @@ fun performDirectionalRaycast(
                 entityName = entity.type.translationKey,
             )
         }
+
         blockDistance < maxDistance -> {
             // Block hit
             val blockPos = blockHitResult.blockPos
@@ -1083,6 +1084,7 @@ fun performDirectionalRaycast(
                 entityName = "",
             )
         }
+
         else -> {
             // Miss
             LidarRayResult(

--- a/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -499,7 +499,9 @@ class MinecraftEnv :
             printWithTime("GLEW not initialized")
             throw RuntimeException("GLEW not initialized")
         }
-        if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY) {
+        if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_TORCH ||
+            initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_JAX
+        ) {
             FramebufferCapturer.initializeZeroCopy(
                 initialEnvironment.imageSizeX,
                 initialEnvironment.imageSizeY,
@@ -819,7 +821,9 @@ class MinecraftEnv :
                     }
                     isOnGround = player.isOnGround
                     isTouchingWater = player.isTouchingWater
-                    if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY) {
+                    if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_TORCH ||
+                        initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_JAX
+                    ) {
                         ipcHandle = FramebufferCapturer.ipcHandle
                     }
                     if (initialEnvironment.requiresDepth) {

--- a/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/ToMessage.kt
+++ b/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/ToMessage.kt
@@ -40,25 +40,28 @@ fun StatusEffectInstance.toMessage() =
 
 fun HitResult.toMessage(world: World) =
     when (type) {
-        HitResult.Type.MISS ->
+        HitResult.Type.MISS -> {
             hitResult {
                 type = com.kyhsgeekcode.minecraftenv.proto.ObservationSpace.HitResult.Type.MISS
             }
+        }
 
-        HitResult.Type.BLOCK ->
+        HitResult.Type.BLOCK -> {
             hitResult {
                 type = com.kyhsgeekcode.minecraftenv.proto.ObservationSpace.HitResult.Type.BLOCK
                 val blockPos = (this@toMessage as BlockHitResult).blockPos
                 val block = world.getBlockState(blockPos).block
                 targetBlock = block.toMessage(blockPos)
             }
+        }
 
-        HitResult.Type.ENTITY ->
+        HitResult.Type.ENTITY -> {
             hitResult {
                 val entity = (this@toMessage as EntityHitResult).entity
                 type = com.kyhsgeekcode.minecraftenv.proto.ObservationSpace.HitResult.Type.ENTITY
                 targetEntity = entity.toMessage()
             }
+        }
     }
 
 fun Block.toMessage(blockPos: BlockPos) =

--- a/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/customentity/OBJLoader.kt
+++ b/minecraft/mc121/src/main/java/com/kyhsgeekcode/minecraftenv/customentity/OBJLoader.kt
@@ -27,9 +27,17 @@ object OBJLoader {
             for (line in lines) {
                 val tokens = line.trim().split("\\s+".toRegex())
                 when (tokens.firstOrNull()) {
-                    "v" -> vertices.addAll(tokens.drop(1).map { it.toFloat() })
-                    "vt" -> uvs.addAll(tokens.drop(1).map { it.toFloat() })
-                    "vn" -> normals.addAll(tokens.drop(1).map { it.toFloat() })
+                    "v" -> {
+                        vertices.addAll(tokens.drop(1).map { it.toFloat() })
+                    }
+
+                    "vt" -> {
+                        uvs.addAll(tokens.drop(1).map { it.toFloat() })
+                    }
+
+                    "vn" -> {
+                        normals.addAll(tokens.drop(1).map { it.toFloat() })
+                    }
 
                     "f" -> {
                         for (i in 1 until tokens.size) {

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/EnvironmentInitializer.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/EnvironmentInitializer.kt
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.components.EditBox
 import net.minecraft.client.gui.components.TabButton
 import net.minecraft.client.gui.components.events.GuiEventListener
 import net.minecraft.client.gui.components.tabs.TabNavigationBar
+import net.minecraft.client.gui.screens.AccessibilityOnboardingScreen
 import net.minecraft.client.gui.screens.GenericMessageScreen
 import net.minecraft.client.gui.screens.PresetFlatWorldScreen
 import net.minecraft.client.gui.screens.TitleScreen
@@ -92,6 +93,16 @@ class EnvironmentInitializer(
         }
         csvLogger.profileStartPrint("Minecraft_env/onInitialize/ClientTick/EnvironmentInitializer/onClientTick")
         disableNarrator(client)
+        val currentScreenBeforeEnteringWorld = client.gui.screen()
+        if (currentScreenBeforeEnteringWorld is AccessibilityOnboardingScreen) {
+            // Fresh options.txt files make vanilla show this screen before the title
+            // screen. Our GUI-driving logic below doesn't know this screen, so left
+            // unhandled it blocks startup forever. Dismiss it the same way Escape/Done
+            // would, which also persists onboardAccessibility=false so it won't reappear.
+            currentScreenBeforeEnteringWorld.onClose()
+            csvLogger.profileEndPrint("Minecraft_env/onInitialize/ClientTick/EnvironmentInitializer/onClientTick")
+            return
+        }
         if (!initialEnvironment.levelDisplayNameToPlay.isNullOrEmpty()) {
             enterExistingWorldUsingGUI(client, initialEnvironment.levelDisplayNameToPlay)
         } else {

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -983,6 +983,7 @@ fun performDirectionalRaycast(
                 entityName = entity.type.descriptionId,
             )
         }
+
         blockDistance < maxDistance -> {
             // Block hit
             val blockPos = (blockHitResult as BlockHitResult).blockPos
@@ -994,6 +995,7 @@ fun performDirectionalRaycast(
                 entityName = "",
             )
         }
+
         else -> {
             // Miss
             LidarRayResult(

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -503,11 +503,11 @@ class MinecraftEnv :
             )
         }
         val colorTextureId = glColorTexture.glId()
-        if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY) {
+        if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_TORCH) {
             // TODO(26_2_phase2_plan.md W3): initializeZeroCopy still expects the mc121-era
             // FBO-attachment-based signature (colorAttachment/depthAttachment ints from
             // Framebuffer, which no longer exists). Needs the texture-based native rewrite.
-            printWithTime("ZEROCOPY mode requested but not yet ported for 26.2 (W3 pending)")
+            printWithTime("ZEROCOPY_TORCH mode requested but not yet ported for 26.2 (W3 pending)")
         }
 
         // request stats from server
@@ -546,7 +546,7 @@ class MinecraftEnv :
                     FramebufferCapturer.captureFramebuffer(
                         colorTextureId,
                         // frameBufferId: unused by the RAW/PNG path (texture-based on 26.2, see
-                        // W3); only the still-unported ZEROCOPY path would read this.
+                        // W3); only the still-unported ZEROCOPY_TORCH path would read this.
                         0,
                         mainRenderTarget.width,
                         mainRenderTarget.height,
@@ -754,7 +754,7 @@ class MinecraftEnv :
                     }
                     isOnGround = player.onGround()
                     isTouchingWater = player.isInWater
-                    if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY) {
+                    if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_TORCH) {
                         ipcHandle = FramebufferCapturer.ipcHandle
                     }
                     if (initialEnvironment.requiresDepth) {

--- a/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
+++ b/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
@@ -15,7 +15,7 @@ import org.lwjgl.opengl.GL30
 // texture-based instead, with the native side owning and caching its own capture FBO (see
 // docs/26_2_phase2_plan.md W3). VULKAN is scaffolding only for now: mc262's Vulkan renderer
 // readback isn't implemented yet, so it fails loudly instead of silently falling back to a
-// slower path in this hot-loop call. ZEROCOPY still uses the old mc121-era frameBufferId-based
+// slower path in this hot-loop call. ZEROCOPY_TORCH still uses the old mc121-era frameBufferId-based
 // native path and isn't wired up for 26.2 yet either (see initializeZeroCopy below).
 object FramebufferCapturer {
     init {
@@ -40,7 +40,7 @@ object FramebufferCapturer {
                 "Vulkan frame capture is not implemented yet for mc262 (encodingMode=VULKAN)",
             )
         }
-        if (encodingMode == ZEROCOPY) {
+        if (encodingMode == ZEROCOPY_TORCH) {
             assert(textureWidth == targetSizeX && textureHeight == targetSizeY)
             return captureFramebufferZerocopyImpl(
                 frameBufferId,
@@ -161,7 +161,7 @@ object FramebufferCapturer {
 
     const val RAW = 0
     const val PNG = 1
-    const val ZEROCOPY = 2
+    const val ZEROCOPY_TORCH = 2
 
     // mc262-only: Vulkan readback. Not implemented yet (see captureFramebuffer above) -
     // reserved so the wire format/proto stays stable once it lands.

--- a/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/ToMessage.kt
+++ b/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/ToMessage.kt
@@ -40,25 +40,28 @@ fun MobEffectInstance.toMessage() =
 
 fun HitResult.toMessage(world: Level) =
     when (type) {
-        HitResult.Type.MISS ->
+        HitResult.Type.MISS -> {
             hitResult {
                 type = com.kyhsgeekcode.minecraftenv.proto.ObservationSpace.HitResult.Type.MISS
             }
+        }
 
-        HitResult.Type.BLOCK ->
+        HitResult.Type.BLOCK -> {
             hitResult {
                 type = com.kyhsgeekcode.minecraftenv.proto.ObservationSpace.HitResult.Type.BLOCK
                 val blockPos = (this@toMessage as BlockHitResult).blockPos
                 val block = world.getBlockState(blockPos).block
                 targetBlock = block.toMessage(blockPos)
             }
+        }
 
-        HitResult.Type.ENTITY ->
+        HitResult.Type.ENTITY -> {
             hitResult {
                 val entity = (this@toMessage as EntityHitResult).entity
                 type = com.kyhsgeekcode.minecraftenv.proto.ObservationSpace.HitResult.Type.ENTITY
                 targetEntity = entity.toMessage()
             }
+        }
     }
 
 fun Block.toMessage(blockPos: BlockPos) =

--- a/shared-native/gl-capture/include/cross_semaphore.h
+++ b/shared-native/gl-capture/include/cross_semaphore.h
@@ -62,8 +62,8 @@ static inline int rk_sema_wait(struct rk_sema *s) {
     DWORD r;
     do {
         r = WaitForSingleObject(s->sem_java, INFINITE);
-    } while (r == WAIT_FAILED && GetLastError() == ERROR_IO_PENDING
-    ); // 적절한 오류 코드로 변경
+    } while (r == WAIT_FAILED &&
+             GetLastError() == ERROR_IO_PENDING); // 적절한 오류 코드로 변경
     return r;
 #else
     int r;

--- a/shared-native/gl-capture/include/framebuffer_capturer.h
+++ b/shared-native/gl-capture/include/framebuffer_capturer.h
@@ -4,4 +4,4 @@
 extern jclass byteStringClass;
 extern jmethodID copyFromMethod;
 
-enum EncodingMode { RAW = 0, PNG = 1, ZEROCOPY = 2 };
+enum EncodingMode { RAW = 0, PNG = 1, ZEROCOPY_TORCH = 2, ZEROCOPY_JAX = 3 };

--- a/shared/native-ipc/cross_semaphore.h
+++ b/shared/native-ipc/cross_semaphore.h
@@ -66,8 +66,8 @@ static inline int rk_sema_wait(struct rk_sema *s) {
     DWORD r;
     do {
         r = WaitForSingleObject(s->sem_python, INFINITE);
-    } while (r == WAIT_FAILED && GetLastError() == ERROR_IO_PENDING
-    ); // 적절한 오류 코드로 변경
+    } while (r == WAIT_FAILED &&
+             GetLastError() == ERROR_IO_PENDING); // 적절한 오류 코드로 변경
     return r;
 #else
     int r;

--- a/shared/native-ipc/cross_semaphore.h
+++ b/shared/native-ipc/cross_semaphore.h
@@ -87,14 +87,6 @@ static inline int rk_sema_post(struct rk_sema *s) {
 #endif
 }
 
-static inline void async_rk_sema_post(struct rk_sema *s) {
-    std::thread([s]() {
-        if (rk_sema_post(s) < 0) {
-            perror("Failed to post semaphore");
-        };
-    }).detach();
-}
-
 static inline void rk_sema_destroy(struct rk_sema *s) {
 #if IS_WINDOWS
     CloseHandle(s->sem_python);

--- a/shared/native-ipc/ipc_apple.mm
+++ b/shared/native-ipc/ipc_apple.mm
@@ -146,7 +146,8 @@ mtl_tensor_from_mach_port(unsigned int machPort, int width, int height) {
                      }];
 
     if (!mtlBuffer) {
-        throw std::runtime_error("Failed to create Metal buffer from IOSurface"
+        throw std::runtime_error(
+            "Failed to create Metal buffer from IOSurface"
         );
     }
 
@@ -156,10 +157,8 @@ mtl_tensor_from_mach_port(unsigned int machPort, int width, int height) {
 #if USE_CUSTOM_DL_PACK_TENSOR
     return py::reinterpret_steal<py::object>(torchTensorFromDLPack(tensor));
 #else
-    return py::reinterpret_steal<py::object>(PyCapsule_New(
-        tensor,
-        "dltensor",
-        [](PyObject *capsule) {
+    return py::reinterpret_steal<py::object>(
+        PyCapsule_New(tensor, "dltensor", [](PyObject *capsule) {
             // If a DLPack consumer already renamed the capsule to
             // "used_dltensor", ownership (and the deleter call) was
             // transferred to it -- calling the deleter again here would be a
@@ -174,7 +173,7 @@ mtl_tensor_from_mach_port(unsigned int machPort, int width, int height) {
             if (tensor) {
                 tensor->deleter(tensor);
             }
-        }
-    ));
+        })
+    );
 #endif
 }

--- a/shared/native-ipc/ipc_cuda.cpp
+++ b/shared/native-ipc/ipc_cuda.cpp
@@ -58,7 +58,8 @@ mtl_tensor_from_cuda_ipc_handle(void *cuda_ipc_handle, int width, int height) {
         (DLManagedTensor *)malloc(sizeof(DLManagedTensor));
 
     if (!tensor) {
-        throw std::runtime_error("Failed to allocate memory for DLManagedTensor"
+        throw std::runtime_error(
+            "Failed to allocate memory for DLManagedTensor"
         );
     }
     tensor->dl_tensor.data = device_ptr;
@@ -75,7 +76,8 @@ mtl_tensor_from_cuda_ipc_handle(void *cuda_ipc_handle, int width, int height) {
     if (!tensor->dl_tensor.strides) {
         free(tensor->dl_tensor.shape);
         free(tensor);
-        throw std::runtime_error("Failed to allocate memory for tensor strides"
+        throw std::runtime_error(
+            "Failed to allocate memory for tensor strides"
         );
     }
     tensor->dl_tensor.strides[0] = width * 4;

--- a/shared/native-ipc/ipc_noboost.cpp
+++ b/shared/native-ipc/ipc_noboost.cpp
@@ -361,11 +361,12 @@ int create_shared_memory_impl(
 void write_to_shared_memory_impl(
     const std::string &p2j_memory_name, const char *data, size_t action_size
 ) {
-    // p2jFd is owned by the shm_fd_cache in get_shared_memory_fd() and is reused
-    // across calls - it must not be close()d here, only by close_shared_memory_fd()
-    // (via destroy_shared_memory_impl). Closing it here left later calls reusing a
-    // cached-but-already-closed fd number, breaking action delivery after the
-    // first write (surfaced as spurious EACCES/EBADF errors from mmap).
+    // p2jFd is owned by the shm_fd_cache in get_shared_memory_fd() and is
+    // reused across calls - it must not be close()d here, only by
+    // close_shared_memory_fd() (via destroy_shared_memory_impl). Closing it
+    // here left later calls reusing a cached-but-already-closed fd number,
+    // breaking action delivery after the first write (surfaced as spurious
+    // EACCES/EBADF errors from mmap).
     int p2jFd = get_shared_memory_fd(p2j_memory_name.c_str());
     if (p2jFd == -1) {
         perror("shm_open failed while writing to shared memory");
@@ -388,11 +389,12 @@ void write_to_shared_memory_impl(
     layout->action_offset = sizeof(SharedMemoryLayout);
     std::memcpy((char *)ptr + layout->action_offset, data, layout->action_size);
     rk_sema_open(&layout->sem_obs_ready);
-    // Must be synchronous: async_rk_sema_post() posts from a detached thread that
-    // captures a pointer into `ptr`, but this function munmap()s `ptr` right after -
-    // the detached thread would then race to dereference already-unmapped memory,
-    // segfaulting nondeterministically (observed on the 2nd+ step in ZEROCOPY/JAX
-    // mode, once earlier bugs stopped masking this path).
+    // Must be synchronous: async_rk_sema_post() posts from a detached thread
+    // that captures a pointer into `ptr`, but this function munmap()s `ptr`
+    // right after - the detached thread would then race to dereference
+    // already-unmapped memory, segfaulting nondeterministically (observed on
+    // the 2nd+ step in ZEROCOPY/JAX mode, once earlier bugs stopped masking
+    // this path).
     if (rk_sema_post(&layout->sem_action_ready) < 0) {
         perror("Failed to post semaphore");
     }

--- a/shared/native-ipc/ipc_noboost.cpp
+++ b/shared/native-ipc/ipc_noboost.cpp
@@ -300,15 +300,6 @@ int create_shared_memory_impl(
     std::lock_guard<std::mutex> lock(shm_map_mutex);
     shm_map[std::this_thread::get_id()] = {p2j_memory_name, j2p_memory_name};
 
-    if (ftruncate(j2pFd, sizeof(J2PSharedMemoryLayout) + data_size) == -1) {
-        perror("ftruncate failed for j2pFd");
-        close(j2pFd);
-        close(p2jFd);
-        shm_unlink(j2p_memory_name.c_str());
-        shm_unlink(p2j_memory_name.c_str());
-        return -1;
-    }
-
     void *ptr = mmap(
         0, shared_memory_size, PROT_READ | PROT_WRITE, MAP_SHARED, p2jFd, 0
     );
@@ -370,7 +361,16 @@ int create_shared_memory_impl(
 void write_to_shared_memory_impl(
     const std::string &p2j_memory_name, const char *data, size_t action_size
 ) {
+    // p2jFd is owned by the shm_fd_cache in get_shared_memory_fd() and is reused
+    // across calls - it must not be close()d here, only by close_shared_memory_fd()
+    // (via destroy_shared_memory_impl). Closing it here left later calls reusing a
+    // cached-but-already-closed fd number, breaking action delivery after the
+    // first write (surfaced as spurious EACCES/EBADF errors from mmap).
     int p2jFd = get_shared_memory_fd(p2j_memory_name.c_str());
+    if (p2jFd == -1) {
+        perror("shm_open failed while writing to shared memory");
+        return;
+    }
     void *ptr = mmap(
         0,
         sizeof(SharedMemoryLayout) + action_size,
@@ -381,7 +381,6 @@ void write_to_shared_memory_impl(
     );
     if (ptr == MAP_FAILED) {
         perror("mmap failed while writing to shared memory");
-        close(p2jFd);
         return;
     }
     SharedMemoryLayout *layout = static_cast<SharedMemoryLayout *>(ptr);
@@ -389,10 +388,16 @@ void write_to_shared_memory_impl(
     layout->action_offset = sizeof(SharedMemoryLayout);
     std::memcpy((char *)ptr + layout->action_offset, data, layout->action_size);
     rk_sema_open(&layout->sem_obs_ready);
-    async_rk_sema_post(&layout->sem_action_ready);
+    // Must be synchronous: async_rk_sema_post() posts from a detached thread that
+    // captures a pointer into `ptr`, but this function munmap()s `ptr` right after -
+    // the detached thread would then race to dereference already-unmapped memory,
+    // segfaulting nondeterministically (observed on the 2nd+ step in ZEROCOPY/JAX
+    // mode, once earlier bugs stopped masking this path).
+    if (rk_sema_post(&layout->sem_action_ready) < 0) {
+        perror("Failed to post semaphore");
+    }
     // std::cout << "Wrote action to shared memory" << std::endl;
     munmap(ptr, sizeof(SharedMemoryLayout) + action_size);
-    close(p2jFd);
 }
 
 py::bytes read_from_shared_memory_impl(
@@ -414,7 +419,6 @@ py::bytes read_from_shared_memory_impl(
     );
     if (p2jPtr == MAP_FAILED) {
         perror("mmap p2j failed while reading from shared memory");
-        close(p2jFd);
         return py::bytes();
     }
     SharedMemoryLayout *layout = static_cast<SharedMemoryLayout *>(p2jPtr);
@@ -453,7 +457,6 @@ py::bytes read_from_shared_memory_impl(
     if (j2pPtr == MAP_FAILED) {
         perror("mmap j2p failed while reading from shared memory");
         munmap(p2jPtr, sizeof(SharedMemoryLayout));
-        close(p2jFd);
         close(j2pFd);
         return py::bytes();
     }
@@ -476,7 +479,6 @@ py::bytes read_from_shared_memory_impl(
     if (j2pPtr == MAP_FAILED) {
         perror("mmap j2p failed while reading from shared memory");
         munmap(p2jPtr, sizeof(SharedMemoryLayout));
-        close(p2jFd);
         close(j2pFd);
         return py::bytes();
     }
@@ -492,7 +494,6 @@ py::bytes read_from_shared_memory_impl(
     //           << std::endl;
     munmap(j2pPtr, sizeof(J2PSharedMemoryLayout) + obs_length);
     munmap(p2jPtr, sizeof(SharedMemoryLayout));
-    close(p2jFd);
     close(j2pFd);
     return data;
 }
@@ -524,7 +525,7 @@ void destroy_shared_memory_impl(
                 rk_sema_destroy(&layout->sem_action_ready);
                 munmap(ptr, sizeof(SharedMemoryLayout));
             }
-            close(p2jFd);
+            close_shared_memory_fd(memory_name);
         }
     }
     shm_unlink(memory_name.c_str());

--- a/src/craftground/environment/environment.py
+++ b/src/craftground/environment/environment.py
@@ -28,7 +28,6 @@ from .socket_ipc import SocketIPC
 
 from ..csv_logger import CsvLogger, LogBackend
 from ..initial_environment_config import InitialEnvironmentConfig
-from ..screen_encoding_modes import ScreenEncodingMode
 import torch
 
 
@@ -105,20 +104,7 @@ class CraftGroundEnvironment(gym.Env):
         self.queued_commands = []
 
         self.process = None
-        # ZEROCOPY_TORCH/ZEROCOPY_JAX only work over the shared-memory IPC path (the
-        # mach-port/CUDA handle they carry is exchanged via BoostIPC); there's no
-        # valid combination of these encoding modes with use_shared_memory=False, so
-        # don't make that a footgun callers have to remember to wire up themselves.
-        requires_shared_memory = self.encoding_mode in (
-            ScreenEncodingMode.ZEROCOPY_TORCH,
-            ScreenEncodingMode.ZEROCOPY_JAX,
-        )
-        if requires_shared_memory and not use_shared_memory:
-            print(
-                f"{self.encoding_mode} requires shared memory IPC; "
-                "forcing use_shared_memory=True."
-            )
-        self.use_shared_memory = use_shared_memory or requires_shared_memory
+        self.use_shared_memory = use_shared_memory
         if env_path is None:
             self.env_path = resolve_runtime_env_path(mc_version)
         else:

--- a/src/craftground/environment/environment.py
+++ b/src/craftground/environment/environment.py
@@ -28,6 +28,7 @@ from .socket_ipc import SocketIPC
 
 from ..csv_logger import CsvLogger, LogBackend
 from ..initial_environment_config import InitialEnvironmentConfig
+from ..screen_encoding_modes import ScreenEncodingMode
 import torch
 
 
@@ -104,7 +105,20 @@ class CraftGroundEnvironment(gym.Env):
         self.queued_commands = []
 
         self.process = None
-        self.use_shared_memory = use_shared_memory
+        # ZEROCOPY_TORCH/ZEROCOPY_JAX only work over the shared-memory IPC path (the
+        # mach-port/CUDA handle they carry is exchanged via BoostIPC); there's no
+        # valid combination of these encoding modes with use_shared_memory=False, so
+        # don't make that a footgun callers have to remember to wire up themselves.
+        requires_shared_memory = self.encoding_mode in (
+            ScreenEncodingMode.ZEROCOPY_TORCH,
+            ScreenEncodingMode.ZEROCOPY_JAX,
+        )
+        if requires_shared_memory and not use_shared_memory:
+            print(
+                f"{self.encoding_mode} requires shared memory IPC; "
+                "forcing use_shared_memory=True."
+            )
+        self.use_shared_memory = use_shared_memory or requires_shared_memory
         if env_path is None:
             self.env_path = resolve_runtime_env_path(mc_version)
         else:

--- a/src/craftground/environment/observation_converter.py
+++ b/src/craftground/environment/observation_converter.py
@@ -68,7 +68,7 @@ class ObservationConverter:
         self.render_action = render_action
         self.render_mode = render_mode
         self.render_alternating_eyes = render_alternating_eyes
-        if output_type == ScreenEncodingMode.ZEROCOPY:
+        if output_type == ScreenEncodingMode.ZEROCOPY_TORCH:
             try:
                 from ..craftground_native import initialize_from_mach_port  # type: ignore
                 from ..craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
@@ -77,7 +77,7 @@ class ObservationConverter:
                     "To use zerocopy encoding mode, please install the craftground[cuda] package on linux or windows."
                     " If this error happens in macOS, please report it to the developers."
                 )
-        if output_type == ScreenEncodingMode.JAX:
+        if output_type == ScreenEncodingMode.ZEROCOPY_JAX:
             try:
                 import jax  # type: ignore
             except ImportError:
@@ -105,7 +105,7 @@ class ObservationConverter:
                 obs_2 = self.convert_raw_observation(observation.image_2)
             self.last_observations[0], self.last_observations[1] = obs_1, obs_2
             return (obs_1, obs_2)
-        elif self.output_type == ScreenEncodingMode.ZEROCOPY:
+        elif self.output_type == ScreenEncodingMode.ZEROCOPY_TORCH:
             if self.is_binocular:
                 raise ValueError("Zerocopy mode does not support binocular vision")
             if self.internal_type == ObservationTensorType.NONE:
@@ -121,14 +121,36 @@ class ObservationConverter:
                     f"Invalid internal type for output {self.output_type}: {self.internal_type}"
                 )
 
-        elif self.output_type == ScreenEncodingMode.JAX:
+        elif self.output_type == ScreenEncodingMode.ZEROCOPY_JAX:
             if self.is_binocular:
                 raise ValueError("JAX mode does not support binocular vision")
+            if self.internal_type == ObservationTensorType.NONE:
+                self.initialize_jax_zerocopy(observation.ipc_handle)
             if self.internal_type == ObservationTensorType.JAX_NP:
-                return (self.last_observations[0], None)
+                # self.last_observations[0] is a torch tensor that's a live view
+                # into the shared GPU buffer Java keeps rewriting every frame (same
+                # as ZEROCOPY mode) - it has to be freshly cloned and converted to
+                # a jax array on every call, not just once, or every frame after
+                # the first would return the same stale first-frame snapshot (jax
+                # arrays are immutable, so there's no in-place-updating jax array
+                # to just re-read the way ZEROCOPY re-reads its torch tensor).
+                import jax.dlpack
+
+                torch_frame = self.last_observations[0].clone()[:, :, [2, 1, 0]].flip(
+                    0
+                )
+                try:
+                    obs_1 = jax.dlpack.from_dlpack(torch_frame)
+                except TypeError:
+                    # No jax Metal/GPU backend installed (needs the separate
+                    # jax-metal plugin) - fall back to a CPU copy instead of
+                    # crashing.
+                    obs_1 = jax.dlpack.from_dlpack(torch_frame.cpu())
+                return (obs_1, None)
             else:
-                pass
-            return self.convert_jax_zerocopy(observation)
+                raise ValueError(
+                    f"Invalid internal type for output {self.output_type}: {self.internal_type}"
+                )
         else:
             raise ValueError(f"Unknown output type: {self.output_type}")
 
@@ -271,9 +293,14 @@ class ObservationConverter:
             # drop alpha, flip y axis, and clone
             self.internal_type = ObservationTensorType.CUDA_DLPACK
 
-    def convert_jax_observation(self, ipc_handle: bytes) -> "JaxArrayType":
-        import jax.numpy as jnp
-        from ..craftground_native import mtl_dlpack_from_mach_port  # type: ignore
+    def initialize_jax_zerocopy(self, ipc_handle: bytes) -> None:
+        # There is no native mach-port -> DLPack export for JAX; the mach-port path
+        # instead reuses the same native call ZEROCOPY uses, which hands back a
+        # torch tensor that's a live view into the shared GPU buffer Java keeps
+        # rewriting every frame. That torch tensor (not a one-off jax conversion
+        # of it) is what gets cached - see the JAX branch of convert() for why.
+        import torch.utils.dlpack
+        from ..craftground_native import initialize_from_mach_port  # type: ignore
         from ..craftground_native import mtl_tensor_from_cuda_mem_handle  # type: ignore
 
         if len(ipc_handle) == 0:
@@ -281,22 +308,12 @@ class ObservationConverter:
         if len(ipc_handle) == 4:
             mach_port = int.from_bytes(ipc_handle, byteorder="little", signed=False)
             print_with_time(f"{mach_port=}")
-            dlpack_capsule = mtl_dlpack_from_mach_port(
+            apple_tensor = initialize_from_mach_port(
                 mach_port, self.image_width, self.image_height
             )
-            if not dlpack_capsule:
-                raise ValueError(f"Failed to initialize from mach port {ipc_handle}.")
-            jax_image = jnp.from_dlpack(dlpack_capsule)
-            # image_tensor = torch.utils.dlpack.from_dlpack(apple_dl_tensor)
-            rgb_array_or_tensor = jax_image
-            print(rgb_array_or_tensor.shape)
-            print(rgb_array_or_tensor.dtype)
-            print(rgb_array_or_tensor.device())
-            self.last_observations[0] = rgb_array_or_tensor
-            # drop alpha, flip y axis, and clone
-            rgb_array_or_tensor = rgb_array_or_tensor.clone()[:, :, [2, 1, 0]].flip(0)
-            self.internal_type = ObservationTensorType.JAX_NP
-            return rgb_array_or_tensor
+            if apple_tensor is None:
+                raise ValueError(f"Failed to initialize from mach port {mach_port}.")
+            self.last_observations[0] = apple_tensor
         else:
             cuda_dlpack = mtl_tensor_from_cuda_mem_handle(
                 ipc_handle,
@@ -305,8 +322,7 @@ class ObservationConverter:
             )
             if not cuda_dlpack:
                 raise ValueError("Invalid DLPack capsule: None")
-            jax_image = jnp.from_dlpack(cuda_dlpack)
-            rgb_array_or_tensor = jax_image
-            rgb_array_or_tensor = rgb_array_or_tensor.clone()[:, :, [2, 1, 0]].flip(0)
-            self.internal_type = ObservationTensorType.JAX_NP
-            return jax_image, None
+            self.last_observations[0] = torch.utils.dlpack.from_dlpack(cuda_dlpack)
+        print(self.last_observations[0].shape)
+        print(self.last_observations[0].dtype)
+        self.internal_type = ObservationTensorType.JAX_NP

--- a/src/craftground/screen_encoding_modes.py
+++ b/src/craftground/screen_encoding_modes.py
@@ -4,5 +4,8 @@ from enum import Enum
 class ScreenEncodingMode(Enum):
     RAW = 0
     PNG = 1
-    ZEROCOPY = 2
-    JAX = 3
+    # Both ZEROCOPY_* variants share the same native mach-port/CUDA-handle capture
+    # path (see FramebufferCapturer.kt) and only differ in which array type the
+    # shared GPU buffer gets wrapped as on the Python side.
+    ZEROCOPY_TORCH = 2
+    ZEROCOPY_JAX = 3


### PR DESCRIPTION
# Pull ##

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/yhs0602/8497c0c395a8d6b18d1e81f05ff57dba/raw/craftground__pull_##.json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added distinct zero-copy screen encoding options for PyTorch and JAX.
  - JAX zero-copy observations now provide immutable JAX arrays with CPU fallback support.

- **Bug Fixes**
  - Automatically dismisses accessibility onboarding screens that could block environment startup.
  - Improved Windows shared-memory cleanup and synchronized semaphore signaling for more reliable IPC.

- **Documentation**
  - Updated architecture documentation to reflect the separate PyTorch and JAX zero-copy modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->