### PR TITLE
mc262: W12 staleness instrumentation, W11/W13 wiring, W1 present-hook capture, W4 GL fail-fast

### DIFF
--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/EnvironmentInitializer.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/EnvironmentInitializer.kt
@@ -140,8 +140,31 @@ class EnvironmentInitializer(
         if (initialEnvironment.noFovEffect) {
             setFovEffectDisabled(client)
         }
+        checkGlBackend(client)
         initializedClient = true
         csvLogger.profileEndPrint("Minecraft_env/onInitialize/ClientTick/EnvironmentInitializer/onClientTick")
+    }
+
+    // W4 (26_2_phase2_plan.md D2): fail fast at initialization if the GL backend isn't in use,
+    // rather than only discovering it on the first captureFramebuffer() call in
+    // MinecraftEnv.sendObservation(). Checked here (once, right before initializedClient is set)
+    // rather than on the very first client tick, because the main render target's color texture
+    // isn't guaranteed to exist yet before a world has been entered - by this point in
+    // onClientTick a world is already up and the render pipeline has run many frames.
+    private fun checkGlBackend(client: Minecraft) {
+        val colorTexture = client.gameRenderer.mainRenderTarget().colorTexture
+        if (colorTexture !is com.mojang.blaze3d.opengl.GlTexture) {
+            val backendName =
+                com.mojang.blaze3d.systems.RenderSystem
+                    .getDevice()
+                    .deviceInfo
+                    .backendName()
+            throw IllegalStateException(
+                "CraftGround requires the OpenGL rendering backend for capture, but the active " +
+                    "backend is '$backendName' (got color texture $colorTexture; see phase2_plan.md D2/W4). " +
+                    "Vulkan is not yet supported.",
+            )
+        }
     }
 
     private fun enterExistingWorldUsingGUI(

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -16,6 +16,7 @@ import com.kyhsgeekcode.minecraftenv.proto.lidarRay
 import com.kyhsgeekcode.minecraftenv.proto.lidarResult
 import com.kyhsgeekcode.minecraftenv.proto.nearbyBiome
 import com.kyhsgeekcode.minecraftenv.proto.observationSpaceMessage
+import com.kyhsgeekcode.minecraftenv.mixin.PacketProcessorQueueAccessor
 import net.fabricmc.api.ClientModInitializer
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents
@@ -84,11 +85,6 @@ enum class IOPhase {
  *
  * NOT yet applied in this file (left for the tasks below - porting them together with this
  * file would have meant guessing at APIs this port couldn't verify without them):
- * - W1 (moving capture to the present()-redirect frame boundary) and W1-a (PacketProcessor
- *   drain) - sendObservation() below still captures directly in END_WORLD_TICK, mc121-style.
- * - W11 (ObservationSource/ServerAuthoritativeSource) - numeric fields below are still read
- *   from the client LocalPlayer, not the server-authoritative ServerPlayer, even though
- *   ObservationSource/ServerAuthoritativeSource already exist (see ObservationSource.kt).
  * - W3/W5 (texture-based capture, present-hook, FramerateLimiter) - the eye-distance ("stereo")
  *   render path below is disabled (throws) rather than ported, because it depends on a
  *   `render(client)` helper that doesn't have a faithful 26.2 equivalent yet: GameRenderer's
@@ -100,6 +96,19 @@ enum class IOPhase {
 class MinecraftEnv :
     ClientModInitializer,
     CommandExecutor {
+    companion object {
+        @Volatile
+        private var instance: MinecraftEnv? = null
+
+        // W1 (26_2_phase2_plan.md §2.2): called from RenderMixin's present()-redirect. Static so
+        // the Java mixin (running in Minecraft's static context) can reach the running
+        // MinecraftEnv instance without holding a reference of its own.
+        @JvmStatic
+        fun onPresentCapture() {
+            instance?.handlePresentCapture()
+        }
+    }
+
     private lateinit var initialEnvironment: InitialEnvironment.InitialEnvironmentMessage
     private var soundListener: MinecraftSoundListener? = null
     private var entityListener: EntityRenderListenerImpl? =
@@ -107,15 +116,37 @@ class MinecraftEnv :
     private var resetPhase: ResetPhase = ResetPhase.END_RESET
     private var deathMessageCollector: GetMessagesInterface? = null
 
-    private val tickSynchronizer = TickSynchronizer()
+    private var skipSync = false
+
+    // W13 (26_2_phase2_plan.md Seam B): tick handlers call stepBarrier, not TickSynchronizer
+    // directly, so a future DistributedBarrier can be swapped in without touching them.
+    private val stepBarrier: StepBarrier = LockStepBarrier(skipSync = { skipSync })
     private val csvLogger = CsvLogger("java_log.csv", enabled = false, profile = false)
 
     private val variableCommandsAfterReset = mutableListOf<String>()
-    private var skipSync = false
     private var ioPhase = IOPhase.BEGINNING
     private var useSharedMemory = false
 
+    // W11 (26_2_phase2_plan.md Seam A): the integrated server, kept so numeric observations can
+    // be read from the authoritative ServerPlayer instead of the client-predicted LocalPlayer.
+    private var minecraftServer: MinecraftServer? = null
+
+    // W12 staleness instrumentation.
+    private var lastStepStartNanos: Long = 0L
+    private var lastServerTickCount: Long = -1L
+
+    // W1 (26_2_phase2_plan.md §2.2): capture+send moved out of END_LEVEL_TICK into the
+    // present-redirect hook (RenderMixin.captureInsteadOfPresent -> onPresentCapture ->
+    // handlePresentCapture below). END_LEVEL_TICK only decides *whether* to capture (based on
+    // ioPhase, same as before) and records the world to capture; messageIO is promoted to a
+    // field so the present-hook (which runs outside the END_LEVEL_TICK closure) can reach it.
+    private lateinit var messageIO: MessageIO
+
+    @Volatile
+    private var pendingObservationWorld: ClientLevel? = null
+
     override fun onInitializeClient() {
+        instance = this
         val isLdPreloadSet = System.getenv("LD_PRELOAD")
         if (isLdPreloadSet != null) {
             println("LD_PRELOAD is set: $isLdPreloadSet")
@@ -123,7 +154,6 @@ class MinecraftEnv :
             println("LD_PRELOAD is not set")
         }
         val socket: SocketChannel
-        val messageIO: MessageIO
         try {
             val portStr = System.getenv("PORT")
             val port = portStr?.toInt() ?: 8000
@@ -226,9 +256,8 @@ class MinecraftEnv :
         )
         ClientTickEvents.END_LEVEL_TICK.register(
             ClientTickEvents.EndLevelTick { world: ClientLevel ->
-                // allow server to start tick
-                tickSynchronizer.notifyServerTickStart()
-                // wait until server tick ends
+                lastStepStartNanos = System.nanoTime()
+                // allow server to start tick, then wait until it ends
                 csvLogger.profileStartPrint(
                     "Minecraft_env/onInitialize/EndWorldTick/WaitServerTickEnds",
                 )
@@ -236,31 +265,49 @@ class MinecraftEnv :
                     csvLogger.log("Skip waiting server world tick ends")
                 } else {
                     csvLogger.log("Wait server world tick ends")
-                    tickSynchronizer.waitForServerTickCompletion()
                 }
+                stepBarrier.onClientTickEnd()
                 csvLogger.profileEndPrint(
                     "Minecraft_env/onInitialize/EndWorldTick/WaitServerTickEnds",
                 )
-                csvLogger.profileStartPrint(
-                    "Minecraft_env/onInitialize/EndWorldTick/SendObservation",
+
+                // W1-a (26_2_phase2_plan.md §1.1, C안): drain packets queued during the server
+                // tick we just waited on, so ClientLevel reflects that tick's authoritative state
+                // before capture. Mixin unnecessary - Minecraft.packetProcessor() and
+                // PacketProcessor.processQueuedPackets() are both public.
+                // W12: measure the queue depth we drained - evidence for whether W1-b's
+                // marker-packet barrier (currently deferred) is actually needed.
+                val client = Minecraft.getInstance()
+                val packetProcessor = client.packetProcessor()
+                val queuedPacketCount =
+                    (packetProcessor as PacketProcessorQueueAccessor).`minecraftEnv$getPacketsToBeHandled`().size
+                packetProcessor.processQueuedPackets()
+                val tickCountDelta = lastServerTickCount - world.gameTime
+                csvLogger.log(
+                    "W12 packetQueueDepthAtDrain=$queuedPacketCount " +
+                        "serverTick=$lastServerTickCount clientReflectedTick=${world.gameTime} " +
+                        "tickCountDelta=$tickCountDelta",
                 )
+
+                // W1: capture+send is no longer done here - only decide *whether* this step
+                // should capture (same ioPhase check as before) and hand the world off to the
+                // present-redirect hook (handlePresentCapture), which fires later in this same
+                // runTick once the frame has actually been rendered (phase2_plan.md §2.2).
                 if (ioPhase ==
                     IOPhase.GOT_INITIAL_ENVIRONMENT_SENT_OBSERVATION_SKIP_SEND_OBSERVATION ||
                     ioPhase == IOPhase.SENT_OBSERVATION_SHOULD_READ_ACTION
                 ) {
-                    // pass
                     csvLogger.log("Skip send observation; $ioPhase")
+                    pendingObservationWorld = null
                 } else {
-                    csvLogger.log("Real send observation; $ioPhase")
-                    sendObservation(messageIO, world)
+                    csvLogger.log("Will send observation at present hook; $ioPhase")
+                    pendingObservationWorld = world
                 }
-                csvLogger.profileEndPrint(
-                    "Minecraft_env/onInitialize/EndWorldTick/SendObservation",
-                )
             },
         )
         ServerTickEvents.START_SERVER_TICK.register(
             ServerTickEvents.StartTick { server: MinecraftServer ->
+                minecraftServer = server
                 // wait until client tick ends
                 printWithTime("Wait client world tick ends")
                 csvLogger.profileStartPrint(
@@ -272,8 +319,8 @@ class MinecraftEnv :
                 } else {
                     csvLogger.log("Real Wait client world tick ends")
                     printWithTime("Real Wait client world tick ends")
-                    tickSynchronizer.waitForClientAction()
                 }
+                stepBarrier.onServerTickStart()
                 csvLogger.profileEndPrint(
                     "Minecraft_env/onInitialize/StartServerTick/WaitClientAction",
                 )
@@ -281,13 +328,15 @@ class MinecraftEnv :
         )
         ServerTickEvents.END_SERVER_TICK.register(
             ServerTickEvents.EndTick { server: MinecraftServer ->
+                minecraftServer = server
+                lastServerTickCount = server.tickCount.toLong()
                 // allow client to end tick
                 printWithTime("Notify server tick completion")
                 csvLogger.log("Notify server tick completion")
                 csvLogger.profileStartPrint(
                     "Minecraft_env/onInitialize/EndServerTick/NotifyClientSendObservation",
                 )
-                tickSynchronizer.notifyClientSendObservation()
+                stepBarrier.onServerTickEnd()
                 csvLogger.profileEndPrint(
                     "Minecraft_env/onInitialize/EndServerTick/NotifyClientSendObservation",
                 )
@@ -373,11 +422,11 @@ class MinecraftEnv :
             printWithTime("Timeout")
             csvLogger.log("Timeout")
         } catch (e: IOException) {
-            tickSynchronizer.terminate()
+            stepBarrier.terminate()
             e.printStackTrace()
             exitProcess(-1)
         } catch (e: Exception) {
-            tickSynchronizer.terminate()
+            stepBarrier.terminate()
             e.printStackTrace()
             exitProcess(-2)
         }
@@ -425,7 +474,7 @@ class MinecraftEnv :
         } else if (command == "exit") {
             printWithTime("Will terminate")
             csvLogger.log("Will terminate")
-            tickSynchronizer.terminate()
+            stepBarrier.terminate()
             // remove the world file
             client.getSingleplayerServer()?.getWorldPath(net.minecraft.world.level.storage.LevelResource.ROOT)?.let {
                 try {
@@ -473,6 +522,27 @@ class MinecraftEnv :
         return false
     }
 
+    // W1 (26_2_phase2_plan.md §2.2): called from RenderMixin.captureInsteadOfPresent via
+    // onPresentCapture(), i.e. from the present()-redirect - after
+    // RenderSystem.getDevice().createCommandEncoder().submit() in the same renderFrame() call
+    // that followed this step's END_LEVEL_TICK. Runs on the client render thread, same as
+    // END_LEVEL_TICK did, so no additional synchronization is needed around pendingObservationWorld
+    // beyond @Volatile (only one frame's worth of state is ever pending at a time - W2 pins
+    // ticksToDo to 1, so exactly one END_LEVEL_TICK precedes each renderFrame() call).
+    private fun handlePresentCapture() {
+        val world = pendingObservationWorld ?: return
+        pendingObservationWorld = null
+        csvLogger.profileStartPrint(
+            "Minecraft_env/onInitialize/EndWorldTick/SendObservation",
+        )
+        sendObservation(messageIO, world)
+        csvLogger.profileEndPrint(
+            "Minecraft_env/onInitialize/EndWorldTick/SendObservation",
+        )
+        val stepDurationMs = (System.nanoTime() - lastStepStartNanos) / 1_000_000.0
+        csvLogger.log("W12 stepDurationMs=$stepDurationMs")
+    }
+
     private fun sendObservation(
         messageIO: MessageIO,
         world: ClientLevel,
@@ -510,9 +580,37 @@ class MinecraftEnv :
             printWithTime("ZEROCOPY_TORCH mode requested but not yet ported for 26.2 (W3 pending)")
         }
 
+        // W11 (26_2_phase2_plan.md §1.3/§6.3 Seam A): read numeric observations from the
+        // authoritative ServerPlayer instead of the client-predicted LocalPlayer. The
+        // TickSynchronizer/StepBarrier lock's happens-before guarantees this is safe without a
+        // packet-arrival barrier - unlike the rendered image, which still goes through
+        // ClientLevel and does not have this guarantee (see §1.3's source-vs-image table).
+        val serverPlayer =
+            minecraftServer?.playerList?.players?.find { it.uuid == player.uuid }
+        val observationSource: ObservationSource =
+            if (serverPlayer != null) {
+                ServerAuthoritativeSource(serverPlayer)
+            } else {
+                csvLogger.log("W11: no matching ServerPlayer found; falling back to client player")
+                // Inline fallback, not a persisted ObservationSource implementation - a real
+                // multiplayer client-fallback source is deferred to §6.5 (YAGNI, §6.4).
+                object : ObservationSource {
+                    override val x get() = player.x
+                    override val y get() = player.y
+                    override val z get() = player.z
+                    override val prevX get() = player.xo
+                    override val prevY get() = player.yo
+                    override val prevZ get() = player.zo
+                    override val pitch get() = player.xRot
+                    override val yaw get() = player.yRot
+                    override val health get() = player.health
+                    override val foodLevel get() = player.foodData.foodLevel
+                    override val saturationLevel get() = player.foodData.saturationLevel
+                    override val isDead get() = player.isDeadOrDying
+                }
+            }
+
         // request stats from server
-        // TODO(W11): use ObservationSource.ServerAuthoritativeSource instead of the client
-        // player directly, per 26_2_phase2_plan.md §1.3 - not yet wired into this file.
         csvLogger.profileStartPrint(
             "Minecraft_env/onInitialize/EndWorldTick/SendObservation/Prepare",
         )
@@ -522,10 +620,7 @@ class MinecraftEnv :
         try {
             val imageByteString1: ByteString
             val imageByteString2: ByteString
-            val oldX = player.x
-            val oldY = player.y
-            val oldZ = player.z
-            val pos = Vec3(oldX, oldY, oldZ)
+            val pos = Vec3(observationSource.x, observationSource.y, observationSource.z)
             if (initialEnvironment.eyeDistance > 0) {
                 // TODO(26_2_phase2_plan.md W1/W3/W5): the stereo (eyeDistance>0) capture path
                 // needs the extract/render/present redesign described in phase2_plan.md §2 -
@@ -573,12 +668,12 @@ class MinecraftEnv :
                     x = pos.x
                     y = pos.y
                     z = pos.z
-                    pitch = player.xRot.toDouble()
-                    yaw = player.yRot.toDouble()
-                    health = player.health.toDouble()
-                    foodLevel = player.foodData.foodLevel.toDouble()
-                    saturationLevel = player.foodData.saturationLevel.toDouble()
-                    isDead = player.isDeadOrDying
+                    pitch = observationSource.pitch.toDouble()
+                    yaw = observationSource.yaw.toDouble()
+                    health = observationSource.health.toDouble()
+                    foodLevel = observationSource.foodLevel.toDouble()
+                    saturationLevel = observationSource.saturationLevel.toDouble()
+                    isDead = observationSource.isDead
                     val allItems =
                         sequenceOf(
                             player.inventory.nonEquipmentItems.asSequence(),
@@ -854,7 +949,7 @@ class MinecraftEnv :
             )
         } catch (e: IOException) {
             e.printStackTrace()
-            tickSynchronizer.terminate()
+            stepBarrier.terminate()
             client.stop()
 
             val threadGroup = Thread.currentThread().threadGroup

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -3,6 +3,7 @@
 package com.kyhsgeekcode.minecraftenv
 
 import com.google.protobuf.ByteString
+import com.kyhsgeekcode.minecraftenv.mixin.PacketProcessorQueueAccessor
 import com.kyhsgeekcode.minecraftenv.proto.ActionSpace.ActionSpaceMessageV2
 import com.kyhsgeekcode.minecraftenv.proto.InitialEnvironment
 import com.kyhsgeekcode.minecraftenv.proto.ObservationSpace
@@ -16,7 +17,6 @@ import com.kyhsgeekcode.minecraftenv.proto.lidarRay
 import com.kyhsgeekcode.minecraftenv.proto.lidarResult
 import com.kyhsgeekcode.minecraftenv.proto.nearbyBiome
 import com.kyhsgeekcode.minecraftenv.proto.observationSpaceMessage
-import com.kyhsgeekcode.minecraftenv.mixin.PacketProcessorQueueAccessor
 import net.fabricmc.api.ClientModInitializer
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/PacketProcessorQueueAccessor.java
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/PacketProcessorQueueAccessor.java
@@ -1,0 +1,14 @@
+package com.kyhsgeekcode.minecraftenv.mixin;
+
+import java.util.Queue;
+import net.minecraft.network.PacketProcessor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+// W12 (docs/26_2_phase2_plan.md): packetsToBeHandled has no public getter or size accessor, but
+// W1-a's drain point (MinecraftEnv.kt, END_LEVEL_TICK) needs its size to measure staleness.
+@Mixin(PacketProcessor.class)
+public interface PacketProcessorQueueAccessor {
+  @Accessor("packetsToBeHandled")
+  Queue<?> minecraftEnv$getPacketsToBeHandled();
+}

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/RenderMixin.java
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/RenderMixin.java
@@ -1,25 +1,30 @@
 package com.kyhsgeekcode.minecraftenv.mixin;
 
+import com.kyhsgeekcode.minecraftenv.MinecraftEnv;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuSurface;
+import com.mojang.blaze3d.textures.GpuTextureView;
 import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-// Port of mc121's RenderMixin (see docs/26_2_phase2_plan.md W5). mc121 redirected
+// Port of mc121's RenderMixin (see docs/26_2_phase2_plan.md W5/W1). mc121 redirected
 // Framebuffer.endWrite()/draw()/Window.swapBuffers() inside MinecraftClient.render(); 26.2's
-// Minecraft.renderFrame(boolean) blits the finished frame onto the window surface and blocks on
-// present()/vsync instead, and additionally sleeps in FramerateLimiter.limitDisplayFPS() when a
-// frame-rate cap is set.
+// Minecraft.renderFrame(boolean) blits the finished frame onto the window surface and presents
+// it instead, and additionally sleeps in FramerateLimiter.limitDisplayFPS() when a frame-rate
+// cap is set.
 //
-// Unlike mc121, this mixin only neutralizes limitDisplayFPS - it does NOT skip
-// GpuSurface.blitFromTexture()/present() (an earlier version of this mixin did, and that broke
-// world creation: Minecraft.doWorldLoad()'s own blocking wait loop
-// (`while (!singleplayerServer.isReady() || gui.overlay() != null)`) also calls
+// An earlier version of this mixin blindly no-op'd GpuSurface.blitFromTexture()/present() (with
+// no GLFW event pump) and that broke world creation: Minecraft.doWorldLoad()'s own blocking wait
+// loop (`while (!singleplayerServer.isReady() || gui.overlay() != null)`) also calls
 // renderFrame(false) directly on every iteration, and skipping present() there left that wait
 // condition unsatisfied forever - confirmed via jstack showing the render thread permanently
-// parked inside that loop with RenderMixin's blit/present redirects active, and the smoke test
-// passing end-to-end as soon as they were removed). Real, correctness-preserving frame-skipping
-// needs the present()-as-capture-hook redesign from W1, not a blind no-op.
+// parked inside that loop, and the smoke test passing end-to-end as soon as the redirects were
+// removed. W1 (phase2_plan.md §2.2) redesigns present() into the actual capture hook instead of
+// a blind no-op, and - mirroring mc121's WindowSwapBuffers redirect, which always polled GLFW
+// events at the equivalent point - keeps pumping GLFW events on every present() call so
+// doWorldLoad()'s loop isn't starved.
 @Mixin(Minecraft.class)
 public class RenderMixin {
   @Redirect(
@@ -27,5 +32,28 @@ public class RenderMixin {
       at = @At(value = "INVOKE", target = "Lnet/minecraft/client/FramerateLimiter;limitDisplayFPS(I)V"))
   private void skipFramerateLimit(int framerateLimit) {
     // do nothing - a headless step must never sleep waiting for a display refresh
+  }
+
+  @Redirect(
+      method = "renderFrame",
+      at =
+          @At(
+              value = "INVOKE",
+              target =
+                  "Lcom/mojang/blaze3d/systems/GpuSurface;blitFromTexture(Lcom/mojang/blaze3d/systems/CommandEncoder;Lcom/mojang/blaze3d/textures/GpuTextureView;)V"))
+  private void skipBlitToScreen(GpuSurface instance, CommandEncoder encoder, GpuTextureView texture) {
+    // do nothing - headless capture doesn't need the frame blitted onto the window surface.
+  }
+
+  @Redirect(
+      method = "renderFrame",
+      at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/GpuSurface;present()V"))
+  private void captureInsteadOfPresent(GpuSurface instance) {
+    // W1 (26_2_phase2_plan.md §2.2): this replaces the real present() call - the present-redirect
+    // frame boundary the capture point moves to. Runs after
+    // RenderSystem.getDevice().createCommandEncoder().submit() (earlier in renderFrame), so GPU
+    // commands are guaranteed submitted before MinecraftEnv reads the color texture.
+    RenderSystemPollEventsInvoker.pollEvents();
+    MinecraftEnv.onPresentCapture();
   }
 }

--- a/minecraft/mc262/src/client/resources/minecraftenv.client.mixins.json
+++ b/minecraft/mc262/src/client/resources/minecraftenv.client.mixins.json
@@ -17,6 +17,7 @@
 		"ClientTickPinMixin",
 		"InputConstantsMixin",
 		"LevelExtractorEntityListenerMixin",
+		"PacketProcessorQueueAccessor",
 		"RenderMixin"
 	],
 	"injectors": {

--- a/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/ObservationSource.kt
+++ b/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/ObservationSource.kt
@@ -11,7 +11,7 @@ import net.minecraft.server.level.ServerPlayer
  * Only the IntegratedServer-backed implementation exists for now; a client-fallback
  * implementation is deferred to the multiplayer scoping in §6.5 (YAGNI, §6.4).
  */
-internal interface ObservationSource {
+interface ObservationSource {
     val x: Double
     val y: Double
     val z: Double
@@ -26,7 +26,7 @@ internal interface ObservationSource {
     val isDead: Boolean
 }
 
-internal class ServerAuthoritativeSource(
+class ServerAuthoritativeSource(
     private val serverPlayer: ServerPlayer,
 ) : ObservationSource {
     override val x: Double get() = serverPlayer.x

--- a/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/StepBarrier.kt
+++ b/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/StepBarrier.kt
@@ -6,7 +6,7 @@ package com.kyhsgeekcode.minecraftenv
  * `LockStepBarrier` vs `NoOpBarrier`. A future `DistributedBarrier` (§6.5) plugs in here
  * without touching the handlers. Do not add a third implementation speculatively (§6.4).
  */
-internal interface StepBarrier {
+interface StepBarrier {
     /** Called at END_WORLD_TICK: let the server proceed, then block for its tick to finish. */
     fun onClientTickEnd()
 
@@ -20,7 +20,7 @@ internal interface StepBarrier {
 }
 
 /** Wraps the existing [TickSynchronizer] condvar rendezvous — the current sync-mode behavior. */
-internal class LockStepBarrier(
+class LockStepBarrier(
     private val skipSync: () -> Boolean,
 ) : StepBarrier {
     private val synchronizer = TickSynchronizer()
@@ -48,7 +48,7 @@ internal class LockStepBarrier(
 }
 
 /** Async mode (W13): no rendezvous at all. Client and server tick independently. */
-internal class NoOpBarrier : StepBarrier {
+class NoOpBarrier : StepBarrier {
     override fun onClientTickEnd() {}
 
     override fun onServerTickStart() {}


### PR DESCRIPTION
## Summary

Implements the remaining Phase 2 items from `docs/26_2_phase2_plan.md`, in the order W12 → W11/W13 wiring → W1/W1-a → W4, so the codebase is in a clean state before Vulkan-backend work starts.

- **W12** — staleness instrumentation routed through `CsvLogger`: packet-queue depth at drain (new `PacketProcessorQueueAccessor` accessor mixin), server-vs-client tick delta, per-step wall-clock time.
- **W11** — `sendObservation()` now reads position/pitch/yaw/health/food/saturation from the authoritative `ServerPlayer` via `ObservationSource`, instead of the client-predicted `LocalPlayer` (falls back to the client player if no matching `ServerPlayer` is found, with a log line).
- **W13** — tick handlers go through `StepBarrier` (`LockStepBarrier`) instead of calling `TickSynchronizer` directly.
- **W1-a** — drains `client.packetProcessor()` right after the server-tick-complete rendezvous, before capture.
- **W1** — capture+send moved out of `END_LEVEL_TICK` into a new `present()`-redirect hook in `RenderMixin`, so the captured frame reflects the tick that was just synchronized instead of the previous frame's snapshot. `blitFromTexture` is also redirected to skip the on-screen blit; `present()` pumps GLFW events before triggering capture (mirroring mc121's `swapBuffers` redirect) specifically to avoid re-triggering the `doWorldLoad()` hang a blind no-op caused previously.
- **W4** — added an init-time `RenderSystem.getDevice()` backend check in `EnvironmentInitializer`, on top of the existing per-observation check in `sendObservation()`.
- Fixed `StepBarrier`/`ObservationSource` visibility: they were `internal`, which is module-scoped in Kotlin and broke cross-source-set access from `MinecraftEnv.kt` (client sourceSet) once actually wired in.

W1-b (marker-packet arrival barrier) is intentionally deferred — per the plan doc, it's only warranted if W12's measurements show meaningful staleness.

## Verification

- Both `main` and `client` source sets compile cleanly (`compileKotlin`/`compileJava`/`compileClientKotlin`/`compileClientJava`).
- Mixin target signatures (`Minecraft.renderFrame`, `GpuSurface.blitFromTexture`/`present`, `PacketProcessor.packetsToBeHandled`) were checked against the real deobfuscated 26.2 jars via `javap` before writing the mixins.
- `./gradlew runClient` applies all mixins without error (no `MixinApplyError`) and reaches the mod's first line of execution before blocking on the Python IPC handshake (expected — no peer connected in this check).

## Not verified

A full `env.reset()`/`step()` round trip through the Python IPC layer — the real test of whether the present-hook redesign avoids the previous `doWorldLoad()` hang under an actual world-creation path. This needs `craftground`/`craftground-runtime-mc262` installed from this local checkout, which wasn't set up in the environment this PR was authored in.

## Test plan

- [ ] Install this checkout as the local `craftground-runtime-mc262` runtime and run `env.reset()` + a few `env.step()` calls end-to-end
- [ ] Confirm a camera-rotation action's effect appears in the observation image within the same step (W1's stated verification scenario)
- [ ] Pull a few steps of `java_log.csv` and sanity-check the W12 `packetQueueDepthAtDrain` / `tickCountDelta` / `stepDurationMs` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headless frame capture that captures rendered frames without displaying them in the game window.
  * Improved observation timing and synchronization across client and server ticks.
  * Observations now prioritize authoritative server-side player state when available.
* **Bug Fixes**
  * Added validation for the OpenGL rendering backend and clearer errors when unsupported rendering backends, including Vulkan, are active.
  * Improved packet processing coordination to reduce stale or delayed observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->