### PR TITLE
fix(mc262): make the 26.2 runtime actually work end-to-end (capture deadlock + dead input)

### DIFF
--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/ClientPredictedSource.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/ClientPredictedSource.kt
@@ -1,0 +1,30 @@
+package com.kyhsgeekcode.minecraftenv
+
+import net.minecraft.client.player.LocalPlayer
+
+/**
+ * Client-side [ObservationSource], reading the client-predicted [LocalPlayer] - the same values
+ * mc121 has always reported.
+ *
+ * This lives in the `client` source set rather than next to [ServerAuthoritativeSource] in `main`
+ * because [LocalPlayer] is a client-only class.
+ *
+ * See the comment at the observation-source selection in `MinecraftEnv.sendObservation` for why
+ * this, rather than [ServerAuthoritativeSource], is currently the one that gets used.
+ */
+class ClientPredictedSource(
+    private val player: LocalPlayer,
+) : ObservationSource {
+    override val x: Double get() = player.x
+    override val y: Double get() = player.y
+    override val z: Double get() = player.z
+    override val prevX: Double get() = player.xo
+    override val prevY: Double get() = player.yo
+    override val prevZ: Double get() = player.zo
+    override val pitch: Float get() = player.xRot
+    override val yaw: Float get() = player.yRot
+    override val health: Float get() = player.health
+    override val foodLevel: Int get() = player.foodData.foodLevel
+    override val saturationLevel: Float get() = player.foodData.saturationLevel
+    override val isDead: Boolean get() = player.isDeadOrDying
+}

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -584,18 +584,25 @@ class MinecraftEnv :
         // authoritative ServerPlayer rather than the client-predicted LocalPlayer, on the theory
         // that the StepBarrier lock's happens-before makes the server copy race-free.
         //
-        // End-to-end testing showed that premise does not hold on 26.2 as currently wired: the
-        // ServerPlayer's values are not merely one tick stale, they never track the client at all.
-        // A camera action that moved the client to yaw=29.85 (and visibly rotated the rendered
-        // frame in the same step, exactly as W1 intends) left serverYaw=0.0 for every subsequent
-        // step. Client->server player state simply is not syncing yet in this port - see the
-        // known-gaps note in the PR/plan - so a server-sourced observation reports values frozen
-        // at spawn, which is strictly worse than the client-predicted values mc121 has always
-        // reported and shipped with.
+        // We read the client player instead, because a server-sourced value structurally cannot
+        // satisfy W1's same-step guarantee. LocalPlayer.sendPosition() runs inside
+        // LocalPlayer.tick(), but camera rotation is applied by Minecraft.runTick's
+        // mouseHandler.handleAccumulatedMovement() call, which happens AFTER the tick loop. So the
+        // rotation produced by this step's action only reaches the server on the following tick -
+        // whereas the observation W1 captures at the end of this same step already reflects it,
+        // both in the rendered frame and in the client player's own yaw (verified end to end: a
+        // +30 deg camera action yields yaw delta 29.85 and a changed image within one step).
+        // Sourcing yaw from the server would report the pre-action value and reintroduce exactly
+        // the off-by-one-step observation that W1 exists to eliminate. This also matches mc121's
+        // long-shipped semantics.
         //
-        // So: read from the client player (mc121's proven semantics) until the sync gap is fixed.
-        // The ObservationSource seam and ServerAuthoritativeSource are kept, so flipping back is a
-        // one-line change once client->server sync actually works and can be re-verified.
+        // (Until the LevelLoadTrackerMixin added alongside this, the ServerPlayer was not merely
+        // one tick behind but permanently frozen at spawn, since LocalPlayer.tick() - and with it
+        // sendPosition() - never ran at all. That is fixed now; the choice above is about
+        // same-step semantics, not about the sync being broken.)
+        //
+        // The ObservationSource seam and ServerAuthoritativeSource are kept, so switching to
+        // server-authoritative numerics is a one-line change if that tradeoff is ever wanted.
         val observationSource: ObservationSource = ClientPredictedSource(player)
 
         // request stats from server

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -580,35 +580,23 @@ class MinecraftEnv :
             printWithTime("ZEROCOPY_TORCH mode requested but not yet ported for 26.2 (W3 pending)")
         }
 
-        // W11 (26_2_phase2_plan.md §1.3/§6.3 Seam A): read numeric observations from the
-        // authoritative ServerPlayer instead of the client-predicted LocalPlayer. The
-        // TickSynchronizer/StepBarrier lock's happens-before guarantees this is safe without a
-        // packet-arrival barrier - unlike the rendered image, which still goes through
-        // ClientLevel and does not have this guarantee (see §1.3's source-vs-image table).
-        val serverPlayer =
-            minecraftServer?.playerList?.players?.find { it.uuid == player.uuid }
-        val observationSource: ObservationSource =
-            if (serverPlayer != null) {
-                ServerAuthoritativeSource(serverPlayer)
-            } else {
-                csvLogger.log("W11: no matching ServerPlayer found; falling back to client player")
-                // Inline fallback, not a persisted ObservationSource implementation - a real
-                // multiplayer client-fallback source is deferred to §6.5 (YAGNI, §6.4).
-                object : ObservationSource {
-                    override val x get() = player.x
-                    override val y get() = player.y
-                    override val z get() = player.z
-                    override val prevX get() = player.xo
-                    override val prevY get() = player.yo
-                    override val prevZ get() = player.zo
-                    override val pitch get() = player.xRot
-                    override val yaw get() = player.yRot
-                    override val health get() = player.health
-                    override val foodLevel get() = player.foodData.foodLevel
-                    override val saturationLevel get() = player.foodData.saturationLevel
-                    override val isDead get() = player.isDeadOrDying
-                }
-            }
+        // W11 (26_2_phase2_plan.md §1.3/§6.3 Seam A) proposed reading numeric observations off the
+        // authoritative ServerPlayer rather than the client-predicted LocalPlayer, on the theory
+        // that the StepBarrier lock's happens-before makes the server copy race-free.
+        //
+        // End-to-end testing showed that premise does not hold on 26.2 as currently wired: the
+        // ServerPlayer's values are not merely one tick stale, they never track the client at all.
+        // A camera action that moved the client to yaw=29.85 (and visibly rotated the rendered
+        // frame in the same step, exactly as W1 intends) left serverYaw=0.0 for every subsequent
+        // step. Client->server player state simply is not syncing yet in this port - see the
+        // known-gaps note in the PR/plan - so a server-sourced observation reports values frozen
+        // at spawn, which is strictly worse than the client-predicted values mc121 has always
+        // reported and shipped with.
+        //
+        // So: read from the client player (mc121's proven semantics) until the sync gap is fixed.
+        // The ObservationSource seam and ServerAuthoritativeSource are kept, so flipping back is a
+        // one-line change once client->server sync actually works and can be re-verified.
+        val observationSource: ObservationSource = ClientPredictedSource(player)
 
         // request stats from server
         csvLogger.profileStartPrint(

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/LevelLoadTrackerMixin.java
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/LevelLoadTrackerMixin.java
@@ -1,0 +1,42 @@
+package com.kyhsgeekcode.minecraftenv.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.LevelLoadTracker;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// 26.2 added a client-loaded handshake that mc121 had no equivalent of, and it silently disables
+// the player until it completes. LocalPlayer.tick() wraps its ENTIRE body in
+// `if (this.connection.hasClientLoaded())`, so while that flag is false the player never runs
+// super.tick() (hence no aiStep() -> no ClientInput.tick(), no movement) and never runs
+// sendPosition() (hence the server's copy of the player stays frozen at spawn). That single flag
+// accounted for every "actions do nothing" symptom seen end-to-end: held movement keys reached
+// KeyMapping.isDown() correctly but the player never moved, and server-side position/rotation
+// never tracked the client at all.
+//
+// ClientPacketListener only sets the flag once LevelLoadTracker.isLevelReady() returns true, and
+// that walks a state machine ending in LevelLoadTracker$WaitingForPlayerChunk, whose readiness
+// condition is `playerSectionReady` - an AtomicBoolean flipped by the level renderer when the
+// chunk section containing the player finishes COMPILING. Gating gameplay on render-thread section
+// compilation is meaningless for a headless agent (the window is deliberately iconified), and the
+// preceding WaitingForServer state has no tick() override at all, so it only advances when the
+// loading packets happen to arrive - the 30s "letting the player into the world anyway" timeout
+// lives inside WaitingForPlayerChunk and does not cover it.
+//
+// So report ready as soon as a level and player actually exist. This reaches the same vanilla
+// completion path (ClientPacketListener.notifyPlayerLoaded() -> ServerboundPlayerLoadedPacket +
+// setClientLoaded(true)) that the vanilla timeout would eventually reach, just without waiting on
+// the renderer. Guarding on level/player being non-null keeps us from announcing "loaded" before
+// the world is actually joined.
+@Mixin(LevelLoadTracker.class)
+public class LevelLoadTrackerMixin {
+  @Inject(method = "isLevelReady", at = @At("HEAD"), cancellable = true)
+  private void reportReadyOnceWorldExists(CallbackInfoReturnable<Boolean> cir) {
+    Minecraft client = Minecraft.getInstance();
+    if (client.level != null && client.player != null) {
+      cir.setReturnValue(true);
+    }
+  }
+}

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/RenderMixin.java
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/RenderMixin.java
@@ -1,59 +1,65 @@
 package com.kyhsgeekcode.minecraftenv.mixin;
 
 import com.kyhsgeekcode.minecraftenv.MinecraftEnv;
-import com.mojang.blaze3d.systems.CommandEncoder;
-import com.mojang.blaze3d.systems.GpuSurface;
-import com.mojang.blaze3d.textures.GpuTextureView;
 import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 // Port of mc121's RenderMixin (see docs/26_2_phase2_plan.md W5/W1). mc121 redirected
-// Framebuffer.endWrite()/draw()/Window.swapBuffers() inside MinecraftClient.render(); 26.2's
-// Minecraft.renderFrame(boolean) blits the finished frame onto the window surface and presents
-// it instead, and additionally sleeps in FramerateLimiter.limitDisplayFPS() when a frame-rate
-// cap is set.
+// Framebuffer.endWrite()/draw()/Window.swapBuffers() inside MinecraftClient.render(); 26.2
+// restructured this enough that the equivalent "skip the screen presentation" trick is actively
+// harmful, so the capture hook is attached differently here. Both facts below were established by
+// disassembling the real 26.2 Minecraft.renderFrame(boolean) and by end-to-end testing:
 //
-// An earlier version of this mixin blindly no-op'd GpuSurface.blitFromTexture()/present() (with
-// no GLFW event pump) and that broke world creation: Minecraft.doWorldLoad()'s own blocking wait
-// loop (`while (!singleplayerServer.isReady() || gui.overlay() != null)`) also calls
-// renderFrame(false) directly on every iteration, and skipping present() there left that wait
-// condition unsatisfied forever - confirmed via jstack showing the render thread permanently
-// parked inside that loop, and the smoke test passing end-to-end as soon as the redirects were
-// removed. W1 (phase2_plan.md §2.2) redesigns present() into the actual capture hook instead of
-// a blind no-op, and - mirroring mc121's WindowSwapBuffers redirect, which always polled GLFW
-// events at the equivalent point - keeps pumping GLFW events on every present() call so
-// doWorldLoad()'s loop isn't starved.
+//  1. renderFrame()'s ENTIRE body is wrapped in `if (!this.windowSurface.isAcquired())`, and
+//     GpuSurface.present() is what RELEASES an acquired surface. So suppressing present() is not
+//     the harmless "don't show it on screen" no-op it was in mc121 - it permanently wedges the
+//     surface in the acquired state, after which every later renderFrame() call returns
+//     immediately without rendering anything at all. That is what broke world creation:
+//     Minecraft.doWorldLoad()'s blocking wait loop (`while (!singleplayerServer.isReady() ||
+//     gui.overlay() != null)`) drives progress by calling renderFrame(false) itself, so once
+//     renderFrame went inert the loop spun forever - reproduced twice and confirmed via jstack
+//     showing the render thread permanently parked there. Adding a GLFW pollEvents() call did NOT
+//     help, because event starvation was never the cause.
+//
+//  2. Both `blitFromTexture(...)` and `present()` are themselves guarded by
+//     `if (this.windowSurface.isAcquired())`, and the surface is only ever acquired when
+//     `!surfaceIsInvalid && !window.isMinimized()`. EnvironmentInitializer iconifies the window on
+//     purpose, so in a normal headless run present() is never invoked in the first place - making
+//     it useless as a capture hook. This is why exactly one observation was produced (during world
+//     load, before the window got iconified) and every subsequent step deadlocked.
+//
+// Hence: don't touch blitFromTexture()/present() at all - vanilla already skips both while the
+// window is minimized - and hang the capture off CommandEncoder.submit() instead. submit() is
+// called unconditionally, exactly once per renderFrame(), and injecting immediately AFTER it still
+// satisfies W1's ordering requirement (phase2_plan.md §2.2) that GPU commands be submitted before
+// MinecraftEnv reads the color texture.
 @Mixin(Minecraft.class)
 public class RenderMixin {
-  @Redirect(
-      method = "renderFrame",
-      at = @At(value = "INVOKE", target = "Lnet/minecraft/client/FramerateLimiter;limitDisplayFPS(I)V"))
-  private void skipFramerateLimit(int framerateLimit) {
-    // do nothing - a headless step must never sleep waiting for a display refresh
-  }
-
   @Redirect(
       method = "renderFrame",
       at =
           @At(
               value = "INVOKE",
-              target =
-                  "Lcom/mojang/blaze3d/systems/GpuSurface;blitFromTexture(Lcom/mojang/blaze3d/systems/CommandEncoder;Lcom/mojang/blaze3d/textures/GpuTextureView;)V"))
-  private void skipBlitToScreen(GpuSurface instance, CommandEncoder encoder, GpuTextureView texture) {
-    // do nothing - headless capture doesn't need the frame blitted onto the window surface.
+              target = "Lnet/minecraft/client/FramerateLimiter;limitDisplayFPS(I)V"))
+  private void skipFramerateLimit(int framerateLimit) {
+    // do nothing - a headless step must never sleep waiting for a display refresh
   }
 
-  @Redirect(
+  @Inject(
       method = "renderFrame",
-      at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/GpuSurface;present()V"))
-  private void captureInsteadOfPresent(GpuSurface instance) {
-    // W1 (26_2_phase2_plan.md §2.2): this replaces the real present() call - the present-redirect
-    // frame boundary the capture point moves to. Runs after
-    // RenderSystem.getDevice().createCommandEncoder().submit() (earlier in renderFrame), so GPU
-    // commands are guaranteed submitted before MinecraftEnv reads the color texture.
-    RenderSystemPollEventsInvoker.pollEvents();
+      at =
+          @At(
+              value = "INVOKE",
+              target = "Lcom/mojang/blaze3d/systems/CommandEncoder;submit()V",
+              shift = At.Shift.AFTER))
+  private void captureAfterSubmit(boolean advanceGameTime, CallbackInfo ci) {
+    // W1 (26_2_phase2_plan.md §2.2): the frame boundary the capture point moves to. Fires on every
+    // frame; MinecraftEnv.onPresentCapture() is a no-op unless the preceding END_LEVEL_TICK marked
+    // an observation as pending, so world-load frames (and any frame outside a step) cost nothing.
     MinecraftEnv.onPresentCapture();
   }
 }

--- a/minecraft/mc262/src/client/resources/minecraftenv.client.mixins.json
+++ b/minecraft/mc262/src/client/resources/minecraftenv.client.mixins.json
@@ -17,6 +17,7 @@
 		"ClientTickPinMixin",
 		"InputConstantsMixin",
 		"LevelExtractorEntityListenerMixin",
+		"LevelLoadTrackerMixin",
 		"PacketProcessorQueueAccessor",
 		"RenderMixin"
 	],

--- a/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/ObservationSource.kt
+++ b/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/ObservationSource.kt
@@ -3,13 +3,21 @@ package com.kyhsgeekcode.minecraftenv
 import net.minecraft.server.level.ServerPlayer
 
 /**
- * Seam A (26_2_phase2_plan.md §6.3). Numeric observation values must not be read
- * directly off the client player — see §1.3 for why that races with packet delivery.
- * [ServerAuthoritativeSource] reads the authoritative [ServerPlayer] instead, which the
- * `TickSynchronizer` lock's happens-before already makes safe (W11).
+ * Seam A (26_2_phase2_plan.md §6.3), the source of the numeric (non-image) observation values.
  *
- * Only the IntegratedServer-backed implementation exists for now; a client-fallback
- * implementation is deferred to the multiplayer scoping in §6.5 (YAGNI, §6.4).
+ * W11's original intent was that these must not be read off the client player — see §1.3 for the
+ * race with packet delivery — and that [ServerAuthoritativeSource] should be used instead, since
+ * the step barrier's happens-before makes the server copy safe to read.
+ *
+ * That is currently NOT the implementation in use. End-to-end testing on 26.2 found the
+ * ServerPlayer's state never tracks the client at all (a camera action that rotated the client to
+ * yaw=29.85 left serverYaw=0.0 indefinitely), because client→server player sync is not yet working
+ * in this port — so a server-sourced observation reports values frozen at spawn. The client-side
+ * `ClientPredictedSource` (in the `client` source set, as `LocalPlayer` is client-only) is wired up
+ * instead, matching mc121's long-shipped semantics.
+ *
+ * [ServerAuthoritativeSource] is kept so this can be flipped back in one line once the sync gap is
+ * fixed and the switch can actually be re-verified end to end.
  */
 interface ObservationSource {
     val x: Double

--- a/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/ObservationSource.kt
+++ b/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/ObservationSource.kt
@@ -9,15 +9,16 @@ import net.minecraft.server.level.ServerPlayer
  * race with packet delivery — and that [ServerAuthoritativeSource] should be used instead, since
  * the step barrier's happens-before makes the server copy safe to read.
  *
- * That is currently NOT the implementation in use. End-to-end testing on 26.2 found the
- * ServerPlayer's state never tracks the client at all (a camera action that rotated the client to
- * yaw=29.85 left serverYaw=0.0 indefinitely), because client→server player sync is not yet working
- * in this port — so a server-sourced observation reports values frozen at spawn. The client-side
- * `ClientPredictedSource` (in the `client` source set, as `LocalPlayer` is client-only) is wired up
- * instead, matching mc121's long-shipped semantics.
+ * That is NOT the implementation currently in use. The client-side `ClientPredictedSource` (in the
+ * `client` source set, since `LocalPlayer` is client-only) is wired up instead, because a
+ * server-sourced value structurally cannot satisfy W1's same-step guarantee: camera rotation is
+ * applied by `Minecraft.runTick`'s `handleAccumulatedMovement()` *after* the tick loop that ran
+ * `LocalPlayer.sendPosition()`, so the server only learns about it on the following tick. Reading
+ * yaw from the server would report the pre-action value and reintroduce the very off-by-one-step
+ * observation W1 exists to remove. This also matches mc121's long-shipped semantics.
  *
- * [ServerAuthoritativeSource] is kept so this can be flipped back in one line once the sync gap is
- * fixed and the switch can actually be re-verified end to end.
+ * [ServerAuthoritativeSource] is kept so switching is a one-line change if that tradeoff is ever
+ * wanted. See the selection site in `MinecraftEnv.sendObservation` for the full rationale.
  */
 interface ObservationSource {
     val x: Double


### PR DESCRIPTION
First real end-to-end run of the 26.2 runtime after v2.7.5 (reset + step loop, mirroring `minecraft-simulator-benchmark`'s smoke tests) **deadlocked**. After fixing that, stepping worked but **every action was a no-op**. Two independent root causes, both found by disassembling the real 26.2 classes and instrumenting the live client.

---

## Bug 1 — capture hook deadlocked the whole runtime

Two things the W1 design assumed away about `Minecraft.renderFrame(boolean)`:

**(a) `present()` is what *releases* the acquired surface — and the whole method is gated on it.**

```java
public void renderFrame(boolean advanceGameTime) {
   if (!this.windowSurface.isAcquired()) {          // ← entire body
      ...
      if (this.windowSurface.isAcquired()) this.windowSurface.present();
   }
}
```

Suppressing `present()` is not the harmless "don't show it on screen" no-op it was in mc121 — it wedges the surface in the acquired state, after which **every later `renderFrame()` returns immediately without rendering anything**. `doWorldLoad()` drives its own wait loop by calling `renderFrame(false)`, so it spun forever (confirmed by jstack — render thread parked in that loop). The previously-added `pollEvents()` mitigation could never have worked; GLFW event starvation was never the cause.

**(b) `present()` is never called at all in a headless run anyway.**

Both `blitFromTexture(...)` and `present()` are guarded by `if (this.windowSurface.isAcquired())`, and the surface is only acquired when `!surfaceIsInvalid && !window.isMinimized()`. `EnvironmentInitializer` **iconifies the window on purpose**, so `present()` is never invoked — useless as a capture hook. Hence exactly **one** observation (produced during world load, before iconifying), then permanent deadlock.

**Fix:** leave `blitFromTexture()`/`present()` alone — vanilla already skips both while minimized — and hang the capture off `CommandEncoder.submit()`, which is unconditional and occurs **exactly once** per `renderFrame` (verified in bytecode: single occurrence). Injecting immediately after it still satisfies W1's ordering requirement (§2.2) that GPU commands be submitted before the color texture is read.

---

## Bug 2 — actions did nothing (`hasClientLoaded()` never became true)

With stepping unblocked, holding `forward` for 12 steps never moved the player, and the server's player stayed frozen at spawn.

Instrumenting the full chain showed the synthetic key press arriving correctly and the player otherwise healthy:

```
ourW=true keyUpIsDown=true inputForward=false inputClass=KeyboardInput
tickCount=12 zza=0.0 removed=false alive=true passenger=false
spectator=false inLevel=true clientLoaded=false screen=null
```

`ClientInput.tick()` is the only thing that populates `keyPresses`, and its sole call site is `LocalPlayer.aiStep()` — so `aiStep()` demonstrably never ran.

**Root cause:** 26.2 added a client-loaded handshake mc121 had no equivalent of. `LocalPlayer.tick()` wraps its **entire** body in `if (this.connection.hasClientLoaded())`, so while false:
- `super.tick()` never runs → no `aiStep()` → no `ClientInput.tick()` → **all movement input ignored**
- `sendPosition()` never runs → **the server never learns the client's position/rotation**

One flag explained every symptom — including the stale `ServerPlayer` state reported earlier.

That flag is only set once `LevelLoadTracker.isLevelReady()` returns true, which ends in `WaitingForPlayerChunk`, whose readiness is an `AtomicBoolean` flipped by the level renderer when the player's chunk section finishes **compiling** — meaningless for a deliberately-iconified headless client. The preceding `WaitingForServer` state has **no `tick()` override at all**, and the 30s "letting the player into the world anyway" timeout lives inside `WaitingForPlayerChunk`, so it does not cover that state.

**Fix:** `LevelLoadTrackerMixin` reports ready as soon as a level and player exist, reaching the same vanilla completion path (`notifyPlayerLoaded()` → `ServerboundPlayerLoadedPacket` + `setClientLoaded(true)`) the vanilla timeout would eventually reach, without waiting on the renderer.

---

## Observation source (W11)

Kept client-side, but for a durable reason rather than "sync is broken" (that was Bug 2 and is fixed here): `sendPosition()` runs inside `LocalPlayer.tick()`, while camera rotation is applied by `runTick`'s `handleAccumulatedMovement()` **after** the tick loop. A server-sourced yaw is therefore structurally one tick behind and would reintroduce exactly the off-by-one-step observation W1 exists to remove. This also matches mc121's long-shipped semantics. The `ObservationSource` seam and `ServerAuthoritativeSource` are kept, so switching is a one-line change.

---

## Verification

Against a real client (`mc_version="26.2"`, socket IPC, local editable install):

- `reset()` succeeds (~17s), `pov` shape `(64, 64, 3) uint8`; reset + 8 steps, no deadlock
- **W1's own verification scenario passes**: a +30° yaw action yields yaw delta **29.85** *and* a changed observation image, **within the same step**, and persists on the next step
- **Movement works**: holding `forward` advances the player every step (z `-72.40 → -70.30` over 12 steps, monotonic; `zza=0.98`, `moveVector=(0.0,1.0)`, `clientLoaded=true`)
- W4's init-time GL fail-fast does not false-positive on the normal OpenGL backend
- `google-java-format` and `ktlint` clean on all touched files

## Notes

- All diagnostic logging added during investigation has been removed.
- A benign pre-existing `ModuleNotFoundError: import of time halted` can appear from `CraftGroundEnvironment.__del__` during interpreter shutdown (shared Python, affects mc121 too, fires after the test passes). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)