### PR TITLE
feat(mc262): add Vulkan capture backend (RAW/PNG/depth/stereo)

### DIFF
--- a/docs/26_2_MigrationPlan.md
+++ b/docs/26_2_MigrationPlan.md
@@ -446,6 +446,15 @@ mapped host-visible memory 접근
 
 가능한 추상화 경계
 
+> **후속 정정 (구현 완료 시점).** 아래의 "backend-neutral Blaze3D abstraction 위에서 캡처하라"는
+> 방향은 맞았지만, 그 아래 제안한 `FrameCaptureBackend` / `CapturedFrame` 인터페이스 계층은
+> **결국 필요하지 않았다**. 26.2의 `CommandEncoder`가 이미 백엔드 중립 readback
+> (`copyTextureToBuffer` + `GpuFence` + `GpuBuffer.map()`)을 제공하기 때문에, 우리 쪽은 캡처
+> 지점에서 두 갈래로 분기하기만 하면 됐다. "분기만 쓰고 다형성은 안 쓴다"는 원칙이 유지된다.
+> 또한 이 절이 경고한 layout transition / staging copy / barrier / fence 문제는 전부
+> `VulkanCommandEncoder` 안에 이미 구현돼 있어서, **네이티브 Vulkan 코드를 한 줄도 쓰지 않았다.**
+> 실제 구현과 검증 절차는 `docs/26_2_vulkan_capture.md`를 참고.
+
 CraftGround가 직접 com.mojang.blaze3d.opengl과 vulkan 구현을 동일 인터페이스로 감싸는 것보다, 가능한 한 Minecraft의 backend-neutral Blaze3D abstraction 위에서 캡처하는 것이 좋습니다.
 
 interface FrameCaptureBackend {

--- a/docs/26_2_vulkan_capture.md
+++ b/docs/26_2_vulkan_capture.md
@@ -1,0 +1,232 @@
+# 26.2 Vulkan 캡처 백엔드
+
+Minecraft 26.2는 OpenGL과 Vulkan을 모두 렌더링 백엔드로 지원한다. Phase 2까지의 mc262 캡처
+경로는 `GlTexture.glId()` → 네이티브 `glReadPixels`에 완전히 묶여 있어서, Vulkan으로 뜨면
+프레임을 한 장도 얻지 못했다. 이 문서는 그 제약을 없앤 **backend-neutral 캡처 경로**를
+설명한다.
+
+## 핵심 결론
+
+**Vulkan readback을 위해 네이티브 Vulkan 코드를 한 줄도 쓰지 않았다.**
+
+`docs/26_2_MigrationPlan.md` §6은 "`gl*`을 `vk*`로 치환하면 안 된다 — layout transition,
+staging copy, barrier, fence, mapped host-visible memory가 필요하다"고 지적했다. 그 지적은
+여전히 맞다. 다만 **그 일을 Blaze3D가 이미 다 해놓았다**: 26.2의 `CommandEncoder`는
+백엔드 중립 GPU→CPU readback API를 노출하고, `VulkanCommandEncoder`가 그 안에서
+`vkCmdCopyImageToBuffer` + barrier를, `GlCommandEncoder`가 PBO + `glReadPixels`를 각각
+구현한다.
+
+따라서 `FrameCaptureBackend` 같은 새 인터페이스 계층도 필요 없었다. 기존의
+"분기만 쓰고 다형성은 안 쓴다" 원칙 그대로, 캡처 지점에서 두 갈래로 나뉜다.
+
+## 디컴파일로 확정한 사실
+
+| 사실 | 근거 |
+|---|---|
+| `CommandEncoder.copyTextureToBuffer(GpuTexture, GpuBuffer, offset, Runnable, mipLevel[, x,y,w,h])` 존재 | `com/mojang/blaze3d/systems/CommandEncoder.java:582,590` |
+| 목적지 버퍼는 **tightly packed** (`w*h*format.blockSize()`) — row padding 없음 | 같은 파일 :606 크기 검증 |
+| `GpuBuffer.map(read, write)` → `GpuBufferSlice.MappedView.data(): ByteBuffer` (direct) | `GpuBufferSlice$MappedView` |
+| `USAGE_MAP_READ=1`, `USAGE_COPY_DST=8`. Vulkan은 MAP_READ에 host-visible+coherent를 강제 | `VulkanGpuBuffer$Direct` 생성자 |
+| MainTarget color = `RGBA8_UNORM`, usage `15` = COPY_DST\|**COPY_SRC**\|TEXTURE_BINDING\|RENDER_ATTACHMENT → 복사 소스로 바로 사용 가능 | `MainTarget.java:16,74` |
+| depth = `D32_FLOAT`, 동일 usage 15 | `MainTarget.java:82` |
+| Vulkan 구현은 `vkCmdCopyImageToBuffer` + `memoryBarrier`. **layout transition 불필요** (MC가 이미지를 GENERAL 레이아웃으로 유지) | `VulkanCommandEncoder.java:733-777` |
+| `copyTextureToBuffer`의 `Runnable callback`은 **즉시 실행되지 않는다** — `queueForDestroy`로 2프레임 뒤 실행 → 동기 readback에 쓸 수 없다 | 같은 파일 :776 |
+| GL/Vulkan fence 모두 `awaitCompletion(timeoutNS)` — **나노초** 단위 | `GlFence.java`, `VulkanCommandEncoder$1.java` |
+
+### fence 순서가 load-bearing한 이유
+
+`GpuFence`는 **생성 시점의 submit index를 캡처**하고, `awaitCompletion()`은 그 인덱스가
+제출되고 완료될 때까지 블록한다.
+
+```java
+// VulkanCommandEncoder$1
+VulkanCommandEncoder$1(VulkanCommandEncoder this$0) {
+    this.submitIndex = this.this$0.currentSubmitIndex;   // <-- 생성 시점
+}
+public boolean awaitCompletion(long timeoutMs) {
+    this.completed = this.this$0.awaitSubmitCompletion(this.submitIndex, timeoutMs);
+}
+```
+
+⇒ **`submit()` 이후에 만든 fence는 아직 제출되지 않은 N+1을 기다리며 영원히 멈춘다.**
+그래서 복사 기록과 fence 무장은 반드시 그 프레임의 `submit()` **이전**이어야 한다.
+
+실제 프레임 흐름:
+
+```
+GameRenderer.render()
+  └ renderLevel() 직후  ── GameRendererDepthCaptureMixin
+        BLAZE3D: Blaze3dCapture.recordDepthReadback()  ← 복사 "기록"만
+                 (여기서 읽을 수 없다: fence를 만들면 지금 쓰고 있는 그 submission을
+                  가리키게 되고, 그건 아직 제출 전이다. 그렇다고 미룰 수도 없다 —
+                  26.2는 GUI 패스 전에 depth를 clear한다.)
+  ...
+CommandEncoder.submit()
+  ├ @At BEFORE : MinecraftEnv.onBeforeSubmitCapture()
+  │                → recordColorReadback() + armFence()      [submit index N]
+  ├ (vanilla)  : N 제출
+  └ @At AFTER  : MinecraftEnv.onPresentCapture()
+                   → awaitPendingFence()  (N 완료 대기)
+                   → readColor() / readPendingDepth()  = map + 변환
+```
+
+**추가 submit이 없다.** GL 백엔드에서도 동일하게 유효하다.
+
+**stereo만 예외**: `renderEyeAndCapture()`는 프레임 중간에 재렌더하고 즉시 픽셀이 필요한데,
+바닐라는 그 프레임을 제출할 생각이 없다. 그래서 `Blaze3dCapture.captureNow()`가
+`record → armFence → submit() → await → map`을 눈마다 한 번씩 직접 수행한다 (눈당 submit 1회).
+
+### 상하 반전 (flip)
+
+Vulkan 경로는 `flipVertically = true`가 필요하다. 근거:
+
+- 26.2 Vulkan 백엔드는 `VulkanRenderPass`에서 **평범한 양수 height 뷰포트**를 설정한다
+  (negative-height viewport 트릭을 쓰지 않는다).
+- 대신 `VulkanRenderPipeline`이 모든 파이프라인에 `frontFace(1)` = `VK_FRONT_FACE_CLOCKWISE`를
+  선언한다. GL 기하는 CCW가 정면인데, **Y축이 뒤집혔을 때만 필요한 winding 보정**이 바로 이것이다.
+
+⇒ Vulkan은 y-down NDC로 렌더하고, 이미지 row 0이 화면 위쪽이다. 반면 `glReadPixels`의 첫 row는
+프레임버퍼 아래쪽이다. 두 경로는 정확히 뒤집혀 있다.
+
+GL 경로는 `flipVertically = false`다 — 이건 추론이 아니라 자명하다:
+`GlCommandEncoder.copyTextureToBuffer`가 문자 그대로 PBO로 `glReadPixels`를 부른다.
+
+이 추론이 틀린 것으로 드러나면 `-Dcraftground.blaze3dFlipVertically=<bool>` 한 줄로 뒤집을 수
+있다 (아래 검증 §3 참고).
+
+## 구현 지도
+
+| 파일 | 역할 |
+|---|---|
+| `minecraft/mc262/src/client/java/.../Blaze3dCapture.kt` | **신규.** backend 판별, readback 버퍼 캐시, record/arm/await/read, depth 선형화, stereo용 `captureNow`. Blaze3D 타입이 client-only라 client 소스셋에 있다 |
+| `.../mixin/RenderMixin.java` | `submit()`에 `@At BEFORE` 훅 추가 (기존 AFTER 훅 유지) |
+| `.../MinecraftEnv.kt` | `GlTexture` 하드 캐스트 제거, `onBeforeSubmitCapture` 배선, 백엔드별 분기, depth 지연 읽기 |
+| `.../mixin/GameRendererDepthCaptureMixin.java` | BLAZE3D면 복사 기록만, GL이면 기존 `captureDepthImpl` |
+| `.../EnvironmentInitializer.kt` | `checkGlBackend` → `checkRenderBackend`. 두 백엔드 모두 허용 + 캡처 경로 로그. Vulkan+ZEROCOPY만 fail-fast |
+| `src/main/java/.../FramebufferCapturer.kt` | `VULKAN=3` 상수 제거, `convertCapturedFrameImpl` 선언 추가. GL 경로는 그대로 |
+| `src/main/cpp/frame_convert.cpp` + `include/frame_convert.h` | **신규.** RGBA→RGB(+flip) 변환과, 두 경로가 공유하는 `makeByteStringFromRgb` (resize/cursor/PNG/ByteString) |
+| `src/main/cpp/framebuffer_capturer.cpp` | 꼬리 로직을 위 헬퍼로 추출해 축소 |
+
+`find_package(Vulkan)`은 없다. Vulkan readback이 전부 Kotlin 쪽 Blaze3D 호출이기 때문이다.
+
+Python 쪽은 **변경 없음**. wire format이 동일하고 백엔드는 Java 런타임에서 자동 감지된다.
+
+### 인코딩 모드와 백엔드는 직교한다
+
+이전 스캐폴딩에는 `FramebufferCapturer.VULKAN = 3`이라는 encoding mode 상수가 있었다. 제거했다.
+
+- Vulkan으로 돌려도 결과는 여전히 RAW 또는 PNG다. 백엔드는 인코딩이 아니다.
+- 게다가 ordinal 3은 Python `ScreenEncodingMode.ZEROCOPY_JAX = 3`과 충돌했다 —
+  JAX 모드를 mc262에서 쓰면 mc262가 그걸 VULKAN으로 읽고 예외를 던졌을 것이다.
+
+## 설정
+
+| 설정 | 기본값 | 용도 |
+|---|---|---|
+| `CRAFTGROUND_CAPTURE_BACKEND` 환경변수 (또는 `-Dcraftground.captureBackend`) = `opengl`\|`blaze3d` | 자동 감지 | 캡처 경로 강제. GL 머신에서 `blaze3d`를 켜서 두 경로를 바이트 단위로 비교하는 용도 |
+| `-Dcraftground.blaze3dFlipVertically=<bool>` | 디바이스가 OpenGL이 아니면 true | 위 flip 추론 무효화 |
+
+## 검증
+
+### 1. 빌드
+
+```bash
+cd minecraft/mc262 && ./gradlew build
+```
+
+(통과 확인됨. `convertCapturedFrameImpl` 심볼이 `libnative-lib.dylib`에 들어간 것도 확인.)
+
+### 2. GL 경로 회귀 없음
+
+`CRAFTGROUND_CAPTURE_BACKEND`를 설정하지 않고 기존 스모크 테스트를 돌린다. GL 머신에서는
+자동 감지가 `OPENGL`을 고르므로 캡처 코드 경로가 이전과 **완전히 동일**해야 한다
+(`glReadPixels` → `makeByteStringFromRgb`, 리팩터링으로 함수만 옮겼을 뿐 로직 동일).
+RAW / PNG / depth / stereo 네 가지를 모두 확인.
+
+### 3. 픽셀 동일성 — flip과 채널 순서를 확정하는 단계
+
+같은 GL 머신에서 같은 시드·같은 액션 시퀀스로 두 번 돌려 프레임을 덤프하고 비교한다.
+
+```bash
+CRAFTGROUND_CAPTURE_BACKEND=opengl  python <smoke_script>   # baseline
+CRAFTGROUND_CAPTURE_BACKEND=blaze3d python <smoke_script>   # 신규 경로
+```
+
+두 덤프는 **바이트 단위로 일치**해야 한다 (GL 디바이스에서는 flip이 false이고 두 경로 모두
+`glReadPixels` 결과를 쓰므로 구조적으로 같아야 한다). 불일치하면:
+
+- 상하 반전 → `blaze3dFlipVertically()` 로직
+- R/B 뒤바뀜 → `frame_convert.cpp`의 채널 순서 (`GlConst.toGlExternalId(RGBA8_UNORM)`가 RGBA인지 확인)
+- 가장자리만 다름 → `resize_pixels` 경계
+
+이 단계가 통과해야 Vulkan 결과를 신뢰할 수 있다.
+
+### 4. Vulkan 실행
+
+`options.txt`의 graphics backend를 Vulkan으로 두거나 GL 백엔드 생성을 실패시켜 26.2가
+Vulkan을 고르게 한 뒤, `EnvironmentInitializer`가 찍는 로그로 확인한다:
+
+```
+CraftGround: rendering backend 'Vulkan' -> capture path BLAZE3D (color texture VulkanGpuTexture)
+```
+
+확인 항목:
+
+- RAW 단안 → GL 결과와 육안/수치 일치 (§3의 baseline 덤프와 비교)
+- depth → 근/원거리 값이 GL depth와 일치 (reverse-Z 선형화가 Kotlin으로 포팅된 것 검증)
+- stereo (`eyeDistance > 0`) → 좌/우 프레임이 다르고 시차 방향이 올바름
+- PNG 모드
+- Vulkan + `ZEROCOPY_TORCH` → 초기화 시점에 명확한 예외 (조용히 깨지지 않음)
+
+### 5. 레이턴시
+
+`csvLogger.profile*`가 이미 `.../SendObservation/Prepare/SingleEye/ByteString` 구간을 찍는다
+(`CRAFTGROUND_JAVA_PROFILE=1`). GL 네이티브 경로 대비 Blaze3D 경로의 스텝 시간을 비교해
+기록한다. 유의미하게 느리면(>2x) 네이티브 Vulkan JNI 경로를 후속 작업으로 올리고, 그 판단
+근거를 여기에 남긴다.
+
+---
+
+## ZEROCOPY (Metal) — 설계만, 미구현
+
+현재 mc262는 **GL ZEROCOPY조차 포팅되지 않은 상태**(W3 pending)다. 26.2에는
+`initializeZeroCopy`에 넘길 FBO 정수가 더 이상 없기 때문이다. 그래서 Vulkan ZEROCOPY는
+선행조건 자체가 비어 있고, 이번 범위에서 제외했다. 아래는 착수할 때를 위한 메모다.
+
+### 걸림돌: MC가 `VK_EXT_metal_objects`를 켜지 않는다
+
+`VulkanBackend.java:59`의 필수 확장 목록은 이게 전부다:
+
+```
+VK_KHR_dynamic_rendering, VK_KHR_push_descriptor, VK_KHR_synchronization2,
+VK_EXT_vertex_attribute_divisor, VK_KHR_swapchain
+```
+
+여기에 조건부로 `VK_KHR_portability_subset`(macOS), `VK_AMD_buffer_marker` /
+`VK_NV_device_diagnostic_checkpoints`, `VK_EXT_multi_draw`가 붙는다
+(`VulkanBackend.java:147-160`).
+
+`VK_EXT_metal_objects`가 없으므로 `vkExportMetalObjectsEXT`도, 이미지 생성 시
+`VkImportMetalTextureInfoEXT`도 쓸 수 없다. **디바이스 생성 시점에 활성화돼 있어야 하는
+확장**이라 사후에 끼워넣을 수 없다.
+
+### 구현 스케치
+
+1. `VulkanBackend`의 `deviceExtensions` 리스트에 `VK_EXT_metal_objects`를 주입하는 mixin
+   (`VulkanBackend.java:147` 부근, 물리 디바이스가 지원할 때만).
+   — Mojang의 디바이스 생성 경로에 개입하는 것이므로 이 방식의 위험도가 가장 높다.
+2. IOSurface 백업 MTLTexture를 만들고 (`shared-native/gl-capture/framebuffer_capturer_apple.mm`의
+   `createSharedIOSurface`가 이미 한다), 그걸 `VkImage`로 import.
+3. 매 프레임 `vkCmdCopyImage`로 MC의 color image → 우리 이미지.
+4. mach port를 Python으로 전달 — **기존 경로 그대로**
+   (`framebuffer_capturer_apple.mm`의 `createMachPortForIOSurface`,
+   `src/craftground/environment/observation_converter.py:254`의 `initialize_from_mach_port`).
+
+**Python 쪽은 변경이 필요 없다.** 지금도 `ipc_handle` 바이트를 mach port로만 해석하고,
+IOSurface가 어느 API로 채워졌는지는 신경 쓰지 않는다.
+
+### 선행 작업 순서
+
+1. mc262 GL ZEROCOPY 포팅 (W3) — texture 기반으로 IOSurface 채우기
+2. Vulkan + `VK_EXT_metal_objects` mixin
+3. 위 3~4단계

--- a/minecraft/mc262/build.gradle
+++ b/minecraft/mc262/build.gradle
@@ -121,8 +121,14 @@ tasks.named('build').configure {
 
 tasks.named('runClient') {
     def nativeLibDir = layout.projectDirectory.asFile
+    // Lets verification runs force Vulkan (or OpenGL) without touching options.txt, e.g.
+    // CRAFTGROUND_MC262_GRAPHICS_BACKEND=VULKAN ./gradlew runClient
+    def forcedBackend = System.getenv('CRAFTGROUND_MC262_GRAPHICS_BACKEND')
     doFirst {
         jvmArgs += "-Djava.library.path=${nativeLibDir}"
+        if (forcedBackend) {
+            args '--graphicsBackend', forcedBackend
+        }
     }
 }
 

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/Blaze3dCapture.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/Blaze3dCapture.kt
@@ -1,0 +1,286 @@
+package com.kyhsgeekcode.minecraftenv
+
+import com.google.protobuf.ByteString
+import com.mojang.blaze3d.buffers.GpuBuffer
+import com.mojang.blaze3d.buffers.GpuFence
+import com.mojang.blaze3d.systems.RenderSystem
+import com.mojang.blaze3d.textures.GpuTexture
+import java.nio.ByteOrder
+
+/**
+ * Backend-neutral frame/depth readback - the path that makes capture work on 26.2's Vulkan
+ * rendering backend. See docs/26_2_vulkan_capture.md.
+ *
+ * It needs no native Vulkan code: Blaze3D already exposes a GPU->CPU readback that both of its
+ * backends implement - `CommandEncoder.copyTextureToBuffer` into a `USAGE_MAP_READ` buffer,
+ * synchronized with a `GpuFence`, then `GpuBuffer.map()`. The only native call left is the
+ * RGBA->RGB conversion (`FramebufferCapturer.convertCapturedFrameImpl`), which reuses the exact
+ * resize/cursor/PNG code the OpenGL path uses, so both paths produce the same wire format.
+ *
+ * This lives in the client source set rather than next to FramebufferCapturer because Blaze3D's
+ * GpuDevice/GpuBuffer/GpuTexture types are client-only.
+ *
+ * **The record/read split is load-bearing.** A `GpuFence` captures the command encoder's *current*
+ * submit index at creation time, and `awaitCompletion()` blocks until that index has been both
+ * submitted and completed. A fence created after `CommandEncoder.submit()` therefore names a
+ * submission that has not been issued yet, and waiting on it hangs. So the copy command must be
+ * recorded and the fence armed *before* the frame's submit ([recordColorReadback] +
+ * [recordDepthReadback] + [armFence], from RenderMixin's before-submit hook and the depth mixin),
+ * and only the wait and the map happen after it ([awaitPendingFence], [readColor],
+ * [readPendingDepth]).
+ */
+object Blaze3dCapture {
+    /**
+     * Which capture path to use. BLAZE3D covers Vulkan (and anything else that isn't OpenGL), but
+     * is also selectable *on* OpenGL - that is what makes the two paths comparable byte-for-byte on
+     * one machine, which is how [blaze3dFlipVertically] below is meant to be validated.
+     */
+    enum class CaptureBackend { OPENGL, BLAZE3D }
+
+    // Set via CRAFTGROUND_CAPTURE_BACKEND=opengl|blaze3d or -Dcraftground.captureBackend=...
+    private val forcedBackend: CaptureBackend? =
+        (System.getenv("CRAFTGROUND_CAPTURE_BACKEND") ?: System.getProperty("craftground.captureBackend"))
+            ?.trim()
+            ?.uppercase()
+            ?.let { name ->
+                CaptureBackend.entries.find { it.name == name }
+                    ?: throw IllegalArgumentException(
+                        "Unknown capture backend '$name'; expected one of ${CaptureBackend.entries}",
+                    )
+            }
+
+    private var detectedBackend: CaptureBackend? = null
+
+    fun backendFor(texture: GpuTexture): CaptureBackend {
+        detectedBackend?.let { return it }
+        val detected =
+            forcedBackend
+                ?: if (texture is com.mojang.blaze3d.opengl.GlTexture) {
+                    CaptureBackend.OPENGL
+                } else {
+                    CaptureBackend.BLAZE3D
+                }
+        detectedBackend = detected
+        return detected
+    }
+
+    // Whether this readback yields rows in the opposite order to glReadPixels, which is what the
+    // rest of the pipeline (and the Python side) is calibrated against.
+    //
+    // OpenGL: never. GlCommandEncoder.copyTextureToBuffer is literally glReadPixels into a PBO, so
+    // it is byte-identical to the native path by construction.
+    //
+    // Vulkan: yes. 26.2's Vulkan backend sets a plain, non-negative-height viewport
+    // (VulkanRenderPass) and compensates by declaring VK_FRONT_FACE_CLOCKWISE in every pipeline
+    // (VulkanRenderPipeline) - the winding fix you only need when the Y axis is flipped relative to
+    // GL. So it renders with y-down NDC, image row 0 is the top of the screen, and
+    // vkCmdCopyImageToBuffer hands back rows in the reverse order to glReadPixels.
+    //
+    // Keyed off the actual device rather than off CaptureBackend, because this path can be forced
+    // on an OpenGL device and there it must stay byte-identical to the native GL path. Override
+    // with -Dcraftground.blaze3dFlipVertically=<bool> if the inference above ever stops holding.
+    private val flipOverride: Boolean? =
+        System.getProperty("craftground.blaze3dFlipVertically")?.toBooleanStrictOrNull()
+
+    private fun blaze3dFlipVertically(): Boolean =
+        flipOverride ?: !RenderSystem
+            .getDevice()
+            .deviceInfo
+            .backendName()
+            .contains("OpenGL", ignoreCase = true)
+
+    private const val READBACK_USAGE = GpuBuffer.USAGE_MAP_READ or GpuBuffer.USAGE_COPY_DST
+    private const val FENCE_TIMEOUT_NANOS = 5_000_000_000L
+
+    private var colorReadbackBuffer: GpuBuffer? = null
+    private var colorReadbackBytes = 0L
+    private var depthReadbackBuffer: GpuBuffer? = null
+    private var depthReadbackBytes = 0L
+
+    // Armed before submit(), consumed after it.
+    private var pendingFence: GpuFence? = null
+    private var pendingColorWidth = 0
+    private var pendingColorHeight = 0
+    private var pendingDepthWidth = 0
+    private var pendingDepthHeight = 0
+    private var pendingDepthNear = 0.0f
+    private var pendingDepthFar = 0.0f
+    private var pendingDepthZZeroToOne = false
+    private var hasPendingDepthReadback = false
+
+    private fun ensureReadback(
+        current: GpuBuffer?,
+        currentBytes: Long,
+        requiredBytes: Long,
+        label: String,
+    ): GpuBuffer =
+        if (current != null && currentBytes == requiredBytes && !current.isClosed) {
+            current
+        } else {
+            current?.close()
+            RenderSystem.getDevice().createBuffer({ label }, READBACK_USAGE, requiredBytes)
+        }
+
+    /** Records a color copy into the readback buffer. Must run before the frame's submit(). */
+    fun recordColorReadback(colorTexture: GpuTexture) {
+        val width = colorTexture.getWidth(0)
+        val height = colorTexture.getHeight(0)
+        val required = width.toLong() * height.toLong() * colorTexture.format.blockSize()
+        val buffer =
+            ensureReadback(colorReadbackBuffer, colorReadbackBytes, required, "CraftGround color readback")
+        colorReadbackBuffer = buffer
+        colorReadbackBytes = required
+        pendingColorWidth = width
+        pendingColorHeight = height
+        RenderSystem.getDevice().createCommandEncoder().copyTextureToBuffer(colorTexture, buffer, 0L, {}, 0)
+    }
+
+    /**
+     * Records a depth copy. Called from the depth mixin, i.e. right after renderLevel() and well
+     * before submit() - which is the other half of why this is a record-now/read-later split: 26.2
+     * clears the depth texture between there and the end of the frame, so the copy cannot wait.
+     */
+    fun recordDepthReadback(
+        depthTexture: GpuTexture,
+        near: Float,
+        far: Float,
+        zZeroToOne: Boolean,
+    ) {
+        val width = depthTexture.getWidth(0)
+        val height = depthTexture.getHeight(0)
+        val required = width.toLong() * height.toLong() * depthTexture.format.blockSize()
+        val buffer =
+            ensureReadback(depthReadbackBuffer, depthReadbackBytes, required, "CraftGround depth readback")
+        depthReadbackBuffer = buffer
+        depthReadbackBytes = required
+        pendingDepthWidth = width
+        pendingDepthHeight = height
+        pendingDepthNear = near
+        pendingDepthFar = far
+        pendingDepthZZeroToOne = zZeroToOne
+        hasPendingDepthReadback = true
+        RenderSystem.getDevice().createCommandEncoder().copyTextureToBuffer(depthTexture, buffer, 0L, {}, 0)
+    }
+
+    /** Arms the fence for the submission that is about to happen. Must run before submit(). */
+    fun armFence() {
+        pendingFence?.close()
+        pendingFence = RenderSystem.getDevice().createCommandEncoder().createFence()
+    }
+
+    /** Waits for the armed submission to finish. Must run after submit(); a no-op if none is armed. */
+    fun awaitPendingFence() {
+        val fence = pendingFence ?: return
+        pendingFence = null
+        fence.use {
+            if (!it.awaitCompletion(FENCE_TIMEOUT_NANOS)) {
+                throw IllegalStateException(
+                    "Timed out after ${FENCE_TIMEOUT_NANOS / 1_000_000}ms waiting for the capture readback to complete",
+                )
+            }
+        }
+    }
+
+    /** Reads back the color copy recorded earlier. Only valid after [awaitPendingFence]. */
+    fun readColor(
+        targetSizeX: Int,
+        targetSizeY: Int,
+        encodingMode: Int,
+        drawCursor: Boolean,
+        xPos: Int,
+        yPos: Int,
+    ): ByteString {
+        val buffer =
+            colorReadbackBuffer
+                ?: throw IllegalStateException("readColor() called without a recorded color readback")
+        return buffer.map(true, false).use { view ->
+            FramebufferCapturer.convertCapturedFrameImpl(
+                view.data(),
+                pendingColorWidth,
+                pendingColorHeight,
+                targetSizeX,
+                targetSizeY,
+                encodingMode,
+                blaze3dFlipVertically(),
+                drawCursor,
+                xPos,
+                yPos,
+            )
+        }
+    }
+
+    /**
+     * Reads back the depth copy recorded by [recordDepthReadback] and linearizes it, matching what
+     * the native GL path (src/main/cpp/depth_capture.cpp) produces. Returns null when nothing was
+     * recorded, i.e. on the OpenGL path, where the depth mixin already holds the finished array.
+     *
+     * Only valid after [awaitPendingFence]; consumes the pending readback.
+     */
+    fun readPendingDepth(requiresDepthConversion: Boolean): FloatArray? {
+        if (!hasPendingDepthReadback) return null
+        hasPendingDepthReadback = false
+        val buffer =
+            depthReadbackBuffer
+                ?: throw IllegalStateException("readPendingDepth() called without a recorded depth readback")
+        val width = pendingDepthWidth
+        val height = pendingDepthHeight
+        val near = pendingDepthNear
+        val far = pendingDepthFar
+        val zZeroToOne = pendingDepthZZeroToOne
+        val flip = blaze3dFlipVertically()
+        return buffer.map(true, false).use { view ->
+            val floats = view.data().order(ByteOrder.nativeOrder()).asFloatBuffer()
+            val out = FloatArray(width * height)
+            for (y in 0 until height) {
+                val srcRow = if (flip) height - 1 - y else y
+                for (x in 0 until width) {
+                    val raw = floats.get(srcRow * width + x)
+                    out[y * width + x] =
+                        if (requiresDepthConversion) {
+                            linearizeReverseZ(raw, near, far, zZeroToOne) / far
+                        } else {
+                            raw
+                        }
+                }
+            }
+            out
+        }
+    }
+
+    /**
+     * Ported verbatim from src/main/cpp/depth_capture.cpp's linearizeReverseZ. 26.2 renders the
+     * level with a reversed depth range, so raw depth 1.0 is the near plane and 0.0 the far plane.
+     */
+    private fun linearizeReverseZ(
+        d: Float,
+        n: Float,
+        f: Float,
+        zZeroToOne: Boolean,
+    ): Float =
+        if (zZeroToOne) {
+            (n * f) / (n + d * (f - n))
+        } else {
+            (2.0f * n * f) / (n + f + (2.0f * d - 1.0f) * (f - n))
+        }
+
+    /**
+     * One-shot variant for the stereo path, which re-renders mid-frame and needs the pixels
+     * immediately rather than at the frame's own submit(). Costs one extra submit per eye, which is
+     * the price of reading a frame vanilla was never going to submit on its own.
+     */
+    fun captureNow(
+        colorTexture: GpuTexture,
+        targetSizeX: Int,
+        targetSizeY: Int,
+        encodingMode: Int,
+        drawCursor: Boolean,
+        xPos: Int,
+        yPos: Int,
+    ): ByteString {
+        recordColorReadback(colorTexture)
+        armFence()
+        RenderSystem.getDevice().createCommandEncoder().submit()
+        awaitPendingFence()
+        return readColor(targetSizeX, targetSizeY, encodingMode, drawCursor, xPos, yPos)
+    }
+}

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/EnvironmentInitializer.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/EnvironmentInitializer.kt
@@ -140,29 +140,45 @@ class EnvironmentInitializer(
         if (initialEnvironment.noFovEffect) {
             setFovEffectDisabled(client)
         }
-        checkGlBackend(client)
+        checkRenderBackend(client)
         initializedClient = true
         csvLogger.profileEndPrint("Minecraft_env/onInitialize/ClientTick/EnvironmentInitializer/onClientTick")
     }
 
-    // W4 (26_2_phase2_plan.md D2): fail fast at initialization if the GL backend isn't in use,
-    // rather than only discovering it on the first captureFramebuffer() call in
+    // W4 (26_2_phase2_plan.md D2): resolve and report the capture path once at initialization,
+    // rather than discovering a bad combination on the first captureFramebuffer() call in
     // MinecraftEnv.sendObservation(). Checked here (once, right before initializedClient is set)
     // rather than on the very first client tick, because the main render target's color texture
     // isn't guaranteed to exist yet before a world has been entered - by this point in
     // onClientTick a world is already up and the render pipeline has run many frames.
-    private fun checkGlBackend(client: Minecraft) {
-        val colorTexture = client.gameRenderer.mainRenderTarget().colorTexture
-        if (colorTexture !is com.mojang.blaze3d.opengl.GlTexture) {
-            val backendName =
-                com.mojang.blaze3d.systems.RenderSystem
-                    .getDevice()
-                    .deviceInfo
-                    .backendName()
+    //
+    // Both backends are supported now (docs/26_2_vulkan_capture.md); the only unsupported
+    // combination left is ZEROCOPY_TORCH off the OpenGL path, which still needs the mc121-era
+    // FBO-based native code.
+    private fun checkRenderBackend(client: Minecraft) {
+        val backendName =
+            com.mojang.blaze3d.systems.RenderSystem
+                .getDevice()
+                .deviceInfo
+                .backendName()
+        val colorTexture =
+            client.gameRenderer.mainRenderTarget().colorTexture
+                ?: throw IllegalStateException(
+                    "Main render target has no color texture; cannot determine the capture backend " +
+                        "(rendering backend is '$backendName').",
+                )
+        val captureBackend = Blaze3dCapture.backendFor(colorTexture)
+        println(
+            "CraftGround: rendering backend '$backendName' -> capture path $captureBackend " +
+                "(color texture ${colorTexture.javaClass.simpleName})",
+        )
+        if (captureBackend != Blaze3dCapture.CaptureBackend.OPENGL &&
+            initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_TORCH
+        ) {
             throw IllegalStateException(
-                "CraftGround requires the OpenGL rendering backend for capture, but the active " +
-                    "backend is '$backendName' (got color texture $colorTexture; see phase2_plan.md D2/W4). " +
-                    "Vulkan is not yet supported.",
+                "ZEROCOPY_TORCH capture requires the OpenGL rendering backend, but the active " +
+                    "backend is '$backendName'. Use RAW or PNG, or force OpenGL " +
+                    "(see docs/26_2_vulkan_capture.md).",
             )
         }
     }

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -83,11 +83,15 @@ enum class IOPhase {
  * - D4: mc121's REALISTIC_HUMAN custom-entity registration is dropped - out of scope
  *   (see phase2_plan.md §4).
  *
+ * Color and depth capture work on both of 26.2's rendering backends. The OpenGL backend keeps the
+ * original native glReadPixels path; anything else (i.e. Vulkan) goes through Blaze3D's own
+ * backend-neutral readback - see Blaze3dCapture.CaptureBackend and
+ * docs/26_2_vulkan_capture.md.
+ *
  * Still unported: the ZEROCOPY_TORCH screen encoding, which needs the same texture-based native
  * rewrite the RGB and depth paths already got (26.2 has no FBO integer to hand to
- * initializeZeroCopy anymore), and the VULKAN encoding, which needs a Vulkan readback that
- * doesn't exist yet. Both fail loudly rather than silently producing garbage. Everything else -
- * single-eye and stereo color capture, depth capture - is ported and verified end to end.
+ * initializeZeroCopy anymore). It fails loudly rather than silently producing garbage. Everything
+ * else - single-eye and stereo color capture, depth capture - is ported and verified end to end.
  */
 class MinecraftEnv :
     ClientModInitializer,
@@ -102,6 +106,15 @@ class MinecraftEnv :
         @JvmStatic
         fun onPresentCapture() {
             instance?.handlePresentCapture()
+        }
+
+        // Called from RenderMixin immediately *before* the frame's CommandEncoder.submit(). Only
+        // the backend-neutral capture path needs it: Blaze3D fences name the submission that is
+        // current when they are created, so both the readback command and its fence have to be in
+        // place before the submit they ride on (see docs/26_2_vulkan_capture.md).
+        @JvmStatic
+        fun onBeforeSubmitCapture() {
+            instance?.handleBeforeSubmitCapture()
         }
     }
 
@@ -528,16 +541,41 @@ class MinecraftEnv :
         return false
     }
 
-    // W1 (26_2_phase2_plan.md §2.2): called from RenderMixin.captureInsteadOfPresent via
-    // onPresentCapture(), i.e. from the present()-redirect - after
-    // RenderSystem.getDevice().createCommandEncoder().submit() in the same renderFrame() call
-    // that followed this step's END_LEVEL_TICK. Runs on the client render thread, same as
-    // END_LEVEL_TICK did, so no additional synchronization is needed around pendingObservationWorld
-    // beyond @Volatile (only one frame's worth of state is ever pending at a time - W2 pins
-    // ticksToDo to 1, so exactly one END_LEVEL_TICK precedes each renderFrame() call).
+    /**
+     * Records this frame's color readback and arms the fence, on the backend-neutral capture path
+     * only. Skipped for stereo, which discards this frame and re-renders per eye
+     * ([renderEyeAndCapture] does its own record/arm/submit), and for ZEROCOPY_TORCH, which doesn't
+     * go through a readback buffer at all.
+     */
+    private fun handleBeforeSubmitCapture() {
+        if (pendingObservationWorld == null) return
+        if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_TORCH) return
+        val client = Minecraft.getInstance()
+        val colorTexture = client.gameRenderer.mainRenderTarget().colorTexture ?: return
+        if (Blaze3dCapture.backendFor(colorTexture) != Blaze3dCapture.CaptureBackend.BLAZE3D) {
+            return
+        }
+        if (initialEnvironment.eyeDistance <= 0) {
+            Blaze3dCapture.recordColorReadback(colorTexture)
+        }
+        // Armed even in the stereo case, because the depth mixin may already have recorded a depth
+        // copy into this same submission.
+        Blaze3dCapture.armFence()
+    }
+
+    // W1 (26_2_phase2_plan.md §2.2): called from RenderMixin.captureAfterSubmit via
+    // onPresentCapture() - after RenderSystem.getDevice().createCommandEncoder().submit() in the
+    // same renderFrame() call that followed this step's END_LEVEL_TICK. Runs on the client render
+    // thread, same as END_LEVEL_TICK did, so no additional synchronization is needed around
+    // pendingObservationWorld beyond @Volatile (only one frame's worth of state is ever pending at
+    // a time - W2 pins ticksToDo to 1, so exactly one END_LEVEL_TICK precedes each renderFrame()
+    // call).
     private fun handlePresentCapture() {
         val world = pendingObservationWorld ?: return
         pendingObservationWorld = null
+        // No-op unless handleBeforeSubmitCapture armed a fence; the submission it names has now
+        // been issued by the submit() this hook sits behind.
+        Blaze3dCapture.awaitPendingFence()
         csvLogger.profileStartPrint(
             "Minecraft_env/onInitialize/EndWorldTick/SendObservation",
         )
@@ -563,15 +601,20 @@ class MinecraftEnv :
      * The 26.2 equivalent of mc121's `render(client)` helper is update() + extract() + render():
      * `update()` re-runs `Camera.update` so the shifted position is picked up, `extract()` rebuilds
      * the render state (including frustum culling) against that camera, and `render()` draws it
-     * into the main render target. `submit()` is deliberately *not* called - the GL backend issues
-     * commands eagerly and the capture's `glReadPixels` is itself a sync point, whereas an extra
-     * `submit()` would advance GlCommandEncoder's frame-fence ring out of step with the real frame.
+     * into the main render target.
+     *
+     * On the OpenGL path `submit()` is deliberately *not* called - the GL backend issues commands
+     * eagerly and the capture's `glReadPixels` is itself a sync point, whereas an extra `submit()`
+     * would advance GlCommandEncoder's frame-fence ring out of step with the real frame. The
+     * backend-neutral path has no such eager sync point: its readback only completes when the
+     * submission carrying it does, so there it *must* submit (once per eye) - see
+     * [Blaze3dCapture.captureNow] and docs/26_2_vulkan_capture.md.
      */
     private fun renderEyeAndCapture(
         client: Minecraft,
         player: LocalPlayer,
         eye: Vec3,
-        colorTextureId: Int,
+        captureBackend: Blaze3dCapture.CaptureBackend,
     ): ByteString {
         val originalXo = player.xo
         val originalYo = player.yo
@@ -585,19 +628,34 @@ class MinecraftEnv :
             client.gameRenderer.extract(deltaTracker, true)
             client.gameRenderer.render(deltaTracker, true)
             val mainRenderTarget = client.gameRenderer.mainRenderTarget()
-            return FramebufferCapturer.captureFramebuffer(
-                colorTextureId,
-                0,
-                mainRenderTarget.width,
-                mainRenderTarget.height,
-                initialEnvironment.imageSizeX,
-                initialEnvironment.imageSizeY,
-                initialEnvironment.screenEncodingMode,
-                false,
-                MouseInfo.showCursor,
-                MouseInfo.mouseX.toInt(),
-                MouseInfo.mouseY.toInt(),
-            )
+            val colorTexture =
+                mainRenderTarget.colorTexture
+                    ?: throw IllegalStateException("Main render target has no color texture to capture")
+            return if (captureBackend == Blaze3dCapture.CaptureBackend.BLAZE3D) {
+                Blaze3dCapture.captureNow(
+                    colorTexture,
+                    initialEnvironment.imageSizeX,
+                    initialEnvironment.imageSizeY,
+                    initialEnvironment.screenEncodingMode,
+                    MouseInfo.showCursor,
+                    MouseInfo.mouseX.toInt(),
+                    MouseInfo.mouseY.toInt(),
+                )
+            } else {
+                FramebufferCapturer.captureFramebuffer(
+                    (colorTexture as com.mojang.blaze3d.opengl.GlTexture).glId(),
+                    0,
+                    mainRenderTarget.width,
+                    mainRenderTarget.height,
+                    initialEnvironment.imageSizeX,
+                    initialEnvironment.imageSizeY,
+                    initialEnvironment.screenEncodingMode,
+                    false,
+                    MouseInfo.showCursor,
+                    MouseInfo.mouseX.toInt(),
+                    MouseInfo.mouseY.toInt(),
+                )
+            }
         } finally {
             player.xo = originalXo
             player.yo = originalYo
@@ -618,23 +676,21 @@ class MinecraftEnv :
             csvLogger.log("Player is null")
             return
         }
-        if (FramebufferCapturer.checkGLEW()) {
-            printWithTime("GLEW initialized")
-        } else {
-            printWithTime("GLEW not initialized")
-            throw RuntimeException("GLEW not initialized")
-        }
         val mainRenderTarget = client.gameRenderer.mainRenderTarget()
-        val glColorTexture = mainRenderTarget.colorTexture as? com.mojang.blaze3d.opengl.GlTexture
-        if (glColorTexture == null) {
-            // 26_2_phase2_plan.md D2/W4: fail fast rather than silently produce garbage
-            // frames if the GL backend isn't in use.
-            throw IllegalStateException(
-                "Expected an OpenGL color texture on the main render target " +
-                    "(got ${mainRenderTarget.colorTexture}); capture requires the GL backend (see phase2_plan.md D2).",
-            )
+        val colorTexture =
+            mainRenderTarget.colorTexture
+                ?: throw IllegalStateException("Main render target has no color texture to capture")
+        val captureBackend = Blaze3dCapture.backendFor(colorTexture)
+        // Only the native GL readback needs GLEW; on the backend-neutral path there may not even be
+        // a GL context, so initializing it would fail for no reason.
+        if (captureBackend == Blaze3dCapture.CaptureBackend.OPENGL) {
+            if (FramebufferCapturer.checkGLEW()) {
+                printWithTime("GLEW initialized")
+            } else {
+                printWithTime("GLEW not initialized")
+                throw RuntimeException("GLEW not initialized")
+            }
         }
-        val colorTextureId = glColorTexture.glId()
         if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_TORCH) {
             // TODO(26_2_phase2_plan.md W3): initializeZeroCopy still expects the mc121-era
             // FBO-attachment-based signature (colorAttachment/depthAttachment ints from
@@ -692,8 +748,8 @@ class MinecraftEnv :
                 csvLogger.profileStartPrint(
                     "Minecraft_env/onInitialize/EndWorldTick/SendObservation/Prepare/StereoEye/ByteString",
                 )
-                imageByteString1 = renderEyeAndCapture(client, player, left, colorTextureId)
-                imageByteString2 = renderEyeAndCapture(client, player, right, colorTextureId)
+                imageByteString1 = renderEyeAndCapture(client, player, left, captureBackend)
+                imageByteString2 = renderEyeAndCapture(client, player, right, captureBackend)
                 csvLogger.profileEndPrint(
                     "Minecraft_env/onInitialize/EndWorldTick/SendObservation/Prepare/StereoEye/ByteString",
                 )
@@ -702,21 +758,34 @@ class MinecraftEnv :
                     "Minecraft_env/onInitialize/EndWorldTick/SendObservation/Prepare/SingleEye/ByteString",
                 )
                 imageByteString1 =
-                    FramebufferCapturer.captureFramebuffer(
-                        colorTextureId,
-                        // frameBufferId: unused by the RAW/PNG path (texture-based on 26.2, see
-                        // W3); only the still-unported ZEROCOPY_TORCH path would read this.
-                        0,
-                        mainRenderTarget.width,
-                        mainRenderTarget.height,
-                        initialEnvironment.imageSizeX,
-                        initialEnvironment.imageSizeY,
-                        initialEnvironment.screenEncodingMode,
-                        false,
-                        MouseInfo.showCursor,
-                        MouseInfo.mouseX.toInt(),
-                        MouseInfo.mouseY.toInt(),
-                    )
+                    if (captureBackend == Blaze3dCapture.CaptureBackend.BLAZE3D) {
+                        // The copy was already recorded before this frame's submit() and waited on
+                        // in handlePresentCapture(); this only maps and converts it.
+                        Blaze3dCapture.readColor(
+                            initialEnvironment.imageSizeX,
+                            initialEnvironment.imageSizeY,
+                            initialEnvironment.screenEncodingMode,
+                            MouseInfo.showCursor,
+                            MouseInfo.mouseX.toInt(),
+                            MouseInfo.mouseY.toInt(),
+                        )
+                    } else {
+                        FramebufferCapturer.captureFramebuffer(
+                            (colorTexture as com.mojang.blaze3d.opengl.GlTexture).glId(),
+                            // frameBufferId: unused by the RAW/PNG path (texture-based on 26.2, see
+                            // W3); only the still-unported ZEROCOPY_TORCH path would read this.
+                            0,
+                            mainRenderTarget.width,
+                            mainRenderTarget.height,
+                            initialEnvironment.imageSizeX,
+                            initialEnvironment.imageSizeY,
+                            initialEnvironment.screenEncodingMode,
+                            false,
+                            MouseInfo.showCursor,
+                            MouseInfo.mouseX.toInt(),
+                            MouseInfo.mouseY.toInt(),
+                        )
+                    }
                 imageByteString2 = ByteString.EMPTY
                 csvLogger.profileEndPrint(
                     "Minecraft_env/onInitialize/EndWorldTick/SendObservation/Prepare/SingleEye/ByteString",
@@ -917,12 +986,15 @@ class MinecraftEnv :
                         ipcHandle = FramebufferCapturer.ipcHandle
                     }
                     if (initialEnvironment.requiresDepth) {
-                        depth.addAll(
-                            (client.gameRenderer as GameRendererDepthCaptureMixinGetterInterface)
+                        // On the backend-neutral path the depth mixin only *recorded* the copy;
+                        // this is where it is finally mapped and linearized. On the OpenGL path
+                        // readPendingDepth() returns null and the mixin already has the array.
+                        val depthBuffer =
+                            Blaze3dCapture.readPendingDepth(
+                                FramebufferCapturer.requiresDepthConversion,
+                            ) ?: (client.gameRenderer as GameRendererDepthCaptureMixinGetterInterface)
                                 .`minecraftEnv$getLastDepthBuffer`()
-                                ?.asIterable()
-                                ?: emptyList(),
-                        )
+                        depth.addAll(depthBuffer?.asIterable() ?: emptyList())
                     }
                     if (initialEnvironment.blockCollisionKeysCount > 0) {
                         blockCollisions.addAll(CollisionListener.blockCollisionInfo)

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/GameRendererDepthCaptureMixin.java
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/GameRendererDepthCaptureMixin.java
@@ -1,5 +1,6 @@
 package com.kyhsgeekcode.minecraftenv.mixin;
 
+import com.kyhsgeekcode.minecraftenv.Blaze3dCapture;
 import com.kyhsgeekcode.minecraftenv.FramebufferCapturer;
 import com.kyhsgeekcode.minecraftenv.GameRendererDepthCaptureMixinGetterInterface;
 import com.mojang.blaze3d.opengl.GlTexture;
@@ -50,20 +51,12 @@ public class GameRendererDepthCaptureMixin implements GameRendererDepthCaptureMi
     if (!RenderSystem.isOnRenderThread()) {
       throw new IllegalStateException("Depth capture must run on the render thread");
     }
-    if (!FramebufferCapturer.INSTANCE.checkGLEW()) {
-      throw new IllegalStateException("GLEW not initialized");
-    }
 
     Minecraft client = Minecraft.getInstance();
     RenderTarget mainRenderTarget = client.gameRenderer.mainRenderTarget();
     GpuTexture depthTexture = mainRenderTarget.getDepthTexture();
-    if (!(depthTexture instanceof GlTexture glDepthTexture)) {
-      // Same fail-fast rationale as the color path (phase2_plan.md D2/W4): a non-GL backend
-      // would silently produce garbage instead of depth.
-      throw new IllegalStateException(
-          "Expected an OpenGL depth texture on the main render target (got "
-              + depthTexture
-              + "); depth capture requires the GL backend (see phase2_plan.md D2).");
+    if (depthTexture == null) {
+      throw new IllegalStateException("Main render target has no depth texture to capture");
     }
 
     // 26.2 computes the level's far plane per frame as max(renderDistance * 4, cloudRange * 16)
@@ -74,9 +67,23 @@ public class GameRendererDepthCaptureMixin implements GameRendererDepthCaptureMi
         client.gameRenderer.gameRenderState().levelRenderState.cameraRenderState.depthFar;
     boolean zZeroToOne = RenderSystem.getDevice().getDeviceInfo().isZZeroToOne();
 
+    if (Blaze3dCapture.INSTANCE.backendFor(depthTexture) == Blaze3dCapture.CaptureBackend.BLAZE3D) {
+      // Backend-neutral path: only *record* the copy here. Reading it would need a fence, and a
+      // fence armed mid-frame would name the submission this very command is being written into -
+      // which submit() has not issued yet. MinecraftEnv maps it after the frame's submit()
+      // instead (Blaze3dCapture.readPendingDepth). The injection point still has to be here,
+      // because the copy command has to precede the clearDepthTexture() that follows.
+      Blaze3dCapture.INSTANCE.recordDepthReadback(
+          depthTexture, Camera.PROJECTION_Z_NEAR, farPlane, zZeroToOne);
+      return;
+    }
+
+    if (!FramebufferCapturer.INSTANCE.checkGLEW()) {
+      throw new IllegalStateException("GLEW not initialized");
+    }
     minecraftEnv$lastDepthBuffer =
         FramebufferCapturer.INSTANCE.captureDepthImpl(
-            glDepthTexture.glId(),
+            ((GlTexture) depthTexture).glId(),
             mainRenderTarget.width,
             mainRenderTarget.height,
             FramebufferCapturer.INSTANCE.getRequiresDepthConversion(),

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/RenderMixin.java
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/RenderMixin.java
@@ -49,6 +49,26 @@ public class RenderMixin {
     // do nothing - a headless step must never sleep waiting for a display refresh
   }
 
+  // Only used by the backend-neutral (Vulkan-capable) capture path; the OpenGL path does all its
+  // work in captureAfterSubmit below and this is a no-op for it.
+  //
+  // Blaze3D readbacks have to be *recorded*, and their fence *armed*, before the submission they
+  // ride on. GpuFence captures the encoder's current submit index at creation time and
+  // awaitCompletion() blocks until that index has been both submitted and completed - so a fence
+  // created after submit() would name a submission that hasn't been issued yet and simply hang.
+  // Hence this second hook, immediately before the same submit() call the one below follows.
+  // See docs/26_2_vulkan_capture.md.
+  @Inject(
+      method = "renderFrame",
+      at =
+          @At(
+              value = "INVOKE",
+              target = "Lcom/mojang/blaze3d/systems/CommandEncoder;submit()V",
+              shift = At.Shift.BEFORE))
+  private void captureBeforeSubmit(boolean advanceGameTime, CallbackInfo ci) {
+    MinecraftEnv.onBeforeSubmitCapture();
+  }
+
   @Inject(
       method = "renderFrame",
       at =

--- a/minecraft/mc262/src/main/cpp/CMakeLists.txt
+++ b/minecraft/mc262/src/main/cpp/CMakeLists.txt
@@ -114,6 +114,11 @@ set(
     ${CMAKE_CURRENT_LIST_DIR}/framebuffer_capturer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rgb_capture.cpp
     ${CMAKE_CURRENT_LIST_DIR}/depth_capture.cpp
+    # CPU-only tail of the capture pipeline, shared by the OpenGL readback and
+    # the backend-neutral Blaze3D/Vulkan one. No Vulkan SDK is needed: the
+    # Vulkan readback itself is done through Blaze3D on the Kotlin side, so
+    # there is deliberately no find_package(Vulkan) here.
+    ${CMAKE_CURRENT_LIST_DIR}/frame_convert.cpp
     ${GL_CAPTURE_DIR}/cursor.cpp
     ${GL_CAPTURE_DIR}/noboost_ipc.cpp
 )

--- a/minecraft/mc262/src/main/cpp/frame_convert.cpp
+++ b/minecraft/mc262/src/main/cpp/frame_convert.cpp
@@ -1,0 +1,211 @@
+#include <cstddef>
+#include <jni.h>
+#include <vector>
+
+#include "cross_gl.h"
+#include "cursor.h"
+#include "frame_convert.h"
+#include "framebuffer_capturer.h"
+#include "png_util.h"
+
+// See include/frame_convert.h and docs/26_2_vulkan_capture.md.
+//
+// Nothing in this file calls OpenGL. It only includes cross_gl.h because
+// GLubyte is the pixel type the rest of the capture code (cursor.cpp,
+// rgb_capture.cpp) already speaks - which is what lets the Vulkan/Blaze3D
+// readback reuse the existing resize/cursor/PNG code verbatim instead of
+// growing a second copy of it.
+
+// **Note**: Flipping should be done in python side (matching rgb_capture.cpp).
+extern "C" GLubyte *resize_pixels(
+    jint &textureWidth,
+    jint &textureHeight,
+    jint &targetSizeX,
+    jint &targetSizeY,
+    GLubyte *pixels
+) {
+    auto *resizedPixels = new GLubyte[targetSizeX * targetSizeY * 3];
+    for (int y = 0; y < targetSizeY; y++) {
+        for (int x = 0; x < targetSizeX; x++) {
+            int srcX = x * textureWidth / targetSizeX;
+            int srcY = y * textureHeight / targetSizeY;
+            int dstIndex = (y * targetSizeX + x) * 3;
+            int srcIndex = (srcY * textureWidth + srcX) * 3;
+            resizedPixels[dstIndex] = pixels[srcIndex];
+            resizedPixels[dstIndex + 1] = pixels[srcIndex + 1];
+            resizedPixels[dstIndex + 2] = pixels[srcIndex + 2];
+        }
+    }
+    return resizedPixels;
+}
+
+jobject makeByteStringFromRgb(
+    JNIEnv *env,
+    GLubyte *pixels,
+    jint srcWidth,
+    jint srcHeight,
+    jint targetSizeX,
+    jint targetSizeY,
+    jint encodingMode,
+    jboolean drawCursor,
+    jint xPos,
+    jint yPos
+) {
+    if (byteStringClass == nullptr || copyFromMethod == nullptr ||
+        env->ExceptionCheck()) {
+        return nullptr;
+    }
+
+    jbyteArray byteArray = nullptr;
+    if (encodingMode == RAW) {
+        byteArray = env->NewByteArray(targetSizeX * targetSizeY * 3);
+        if (byteArray == nullptr || env->ExceptionCheck()) {
+            return nullptr;
+        }
+    }
+
+    bool resized = false;
+    if (srcWidth != targetSizeX || srcHeight != targetSizeY) {
+        pixels = resize_pixels(
+            srcWidth, srcHeight, targetSizeX, targetSizeY, pixels
+        );
+        resized = true;
+    }
+
+    if (drawCursor && xPos >= 0 && xPos < targetSizeX && yPos >= 0 &&
+        yPos < targetSizeY) {
+        drawCursorCPU(xPos, yPos, targetSizeX, targetSizeY, pixels);
+    }
+
+    if (encodingMode == PNG) {
+#ifdef HAS_PNG
+        std::vector<ui8> imageBytes;
+        WritePngToMemory(
+            (size_t)targetSizeX, (size_t)targetSizeY, pixels, imageBytes
+        );
+        byteArray = env->NewByteArray(imageBytes.size());
+        env->SetByteArrayRegion(
+            byteArray,
+            0,
+            imageBytes.size(),
+            reinterpret_cast<jbyte *>(imageBytes.data())
+        );
+#else
+        if (resized) {
+            delete[] pixels;
+        }
+        env->ThrowNew(
+            env->FindClass("java/lang/RuntimeException"),
+            "PNG encoding is not supported on this platform: Could not find "
+            "libpng"
+        );
+        return nullptr;
+#endif
+    } else if (encodingMode == RAW) {
+        env->SetByteArrayRegion(
+            byteArray,
+            0,
+            targetSizeX * targetSizeY * 3,
+            reinterpret_cast<jbyte *>(pixels)
+        );
+    }
+
+    jobject byteStringObject =
+        env->CallStaticObjectMethod(byteStringClass, copyFromMethod, byteArray);
+    if (byteArray != nullptr) {
+        env->DeleteLocalRef(byteArray);
+    }
+    if (resized) {
+        delete[] pixels;
+    }
+    if (byteStringObject == nullptr || env->ExceptionCheck()) {
+        return nullptr;
+    }
+    return byteStringObject;
+}
+
+// Scratch buffer for the RGBA -> RGB conversion below. Reused across frames
+// like rgb_capture.cpp's, since the capture runs once per environment step.
+static GLubyte *rgbScratch = nullptr;
+static size_t rgbScratchSize = 0;
+
+static GLubyte *ensureRgbScratch(size_t size) {
+    if (size != rgbScratchSize) {
+        delete[] rgbScratch;
+        rgbScratch = new GLubyte[size];
+        rgbScratchSize = size;
+    }
+    return rgbScratch;
+}
+
+// Backend-neutral entry point: takes the direct ByteBuffer that
+// GpuBuffer.map() handed back after CommandEncoder.copyTextureToBuffer(), which
+// is tightly packed RGBA8 (CommandEncoder sizes the destination as
+// width * height * format.blockSize(), so there is no row padding to skip).
+//
+// `flipVertically` exists because the two backends disagree - or may disagree -
+// on row order: the GL path reads through glReadPixels, whose first row is the
+// framebuffer's bottom row, whereas vkCmdCopyImageToBuffer emits image row 0
+// first. The flag lets the Kotlin side pin the convention down per backend
+// without a rebuild (see docs/26_2_vulkan_capture.md, verification step 3).
+extern "C" JNIEXPORT jobject JNICALL
+Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_convertCapturedFrameImpl(
+    JNIEnv *env,
+    jclass clazz,
+    jobject srcBuffer,
+    jint srcWidth,
+    jint srcHeight,
+    jint targetSizeX,
+    jint targetSizeY,
+    jint encodingMode,
+    jboolean flipVertically,
+    jboolean drawCursor,
+    jint xPos,
+    jint yPos
+) {
+    auto *src =
+        static_cast<const GLubyte *>(env->GetDirectBufferAddress(srcBuffer));
+    if (src == nullptr) {
+        env->ThrowNew(
+            env->FindClass("java/lang/IllegalArgumentException"),
+            "convertCapturedFrameImpl expects a direct ByteBuffer"
+        );
+        return nullptr;
+    }
+    const jlong capacity = env->GetDirectBufferCapacity(srcBuffer);
+    const jlong required = (jlong)srcWidth * (jlong)srcHeight * 4;
+    if (capacity < required) {
+        env->ThrowNew(
+            env->FindClass("java/lang/IllegalArgumentException"),
+            "convertCapturedFrameImpl: buffer smaller than srcWidth*srcHeight*4"
+        );
+        return nullptr;
+    }
+
+    GLubyte *rgb = ensureRgbScratch((size_t)srcWidth * (size_t)srcHeight * 3);
+    for (int y = 0; y < srcHeight; y++) {
+        const int srcRow = flipVertically ? (srcHeight - 1 - y) : y;
+        const GLubyte *srcPixel = src + (size_t)srcRow * srcWidth * 4;
+        GLubyte *dstPixel = rgb + (size_t)y * srcWidth * 3;
+        for (int x = 0; x < srcWidth; x++) {
+            dstPixel[0] = srcPixel[0];
+            dstPixel[1] = srcPixel[1];
+            dstPixel[2] = srcPixel[2];
+            srcPixel += 4;
+            dstPixel += 3;
+        }
+    }
+
+    return makeByteStringFromRgb(
+        env,
+        rgb,
+        srcWidth,
+        srcHeight,
+        targetSizeX,
+        targetSizeY,
+        encodingMode,
+        drawCursor,
+        xPos,
+        yPos
+    );
+}

--- a/minecraft/mc262/src/main/cpp/framebuffer_capturer.cpp
+++ b/minecraft/mc262/src/main/cpp/framebuffer_capturer.cpp
@@ -5,6 +5,7 @@
 #include "png_util.h"
 #include "cursor.h"
 #include "depth_capture.h"
+#include "frame_convert.h"
 #include "rgb_capture.h"
 #include "framebuffer_capturer.h"
 
@@ -124,28 +125,6 @@ Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_initializeGLEW(
 #endif
 }
 
-extern "C" GLubyte *resize_pixels(
-    jint &textureWidth,
-    jint &textureHeight,
-    jint &targetSizeX,
-    jint &targetSizeY,
-    GLubyte *pixels
-) {
-    auto *resizedPixels = new GLubyte[targetSizeX * targetSizeY * 3];
-    for (int y = 0; y < targetSizeY; y++) {
-        for (int x = 0; x < targetSizeX; x++) {
-            int srcX = x * textureWidth / targetSizeX;
-            int srcY = y * textureHeight / targetSizeY;
-            int dstIndex = (y * targetSizeX + x) * 3;
-            int srcIndex = (srcY * textureWidth + srcX) * 3;
-            resizedPixels[dstIndex] = pixels[srcIndex];
-            resizedPixels[dstIndex + 1] = pixels[srcIndex + 1];
-            resizedPixels[dstIndex + 2] = pixels[srcIndex + 2];
-        }
-    }
-    return resizedPixels;
-}
-
 extern "C" JNIEXPORT jobject JNICALL
 Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_captureFramebufferImpl(
     JNIEnv *env,
@@ -161,88 +140,22 @@ Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_captureFramebufferImpl(
     jint xPos,
     jint yPos
 ) {
-    if (byteStringClass == nullptr || env->ExceptionCheck()) {
-        // Handle error
-        return nullptr;
-    }
-    if (copyFromMethod == nullptr || env->ExceptionCheck()) {
-        // Handle error
-        return nullptr;
-    }
-    jbyteArray byteArray = nullptr;
-    if (encodingMode == RAW) {
-        byteArray = env->NewByteArray(targetSizeX * targetSizeY * 3);
-        if (byteArray == nullptr || env->ExceptionCheck()) {
-            // Handle error
-            return nullptr;
-        }
-    }
-
+    // The GL-specific part is just the readback; everything after it (resize,
+    // cursor, RAW/PNG encoding, ByteString) is shared with the backend-neutral
+    // Blaze3D path in frame_convert.cpp.
     GLubyte *pixels = caputreRGB(textureId, textureWidth, textureHeight);
-    bool resized = false;
-    // resize if needed
-    if (textureWidth != targetSizeX || textureHeight != targetSizeY) {
-        pixels = resize_pixels(
-            textureWidth, textureHeight, targetSizeX, targetSizeY, pixels
-        );
-        resized = true;
-    }
-
-    // Draw cursor
-    if (drawCursor && xPos >= 0 && xPos < targetSizeX && yPos >= 0 &&
-        yPos < targetSizeY) {
-        drawCursorCPU(xPos, yPos, targetSizeX, targetSizeY, pixels);
-    }
-
-    // make png bytes from the pixels
-    if (encodingMode == PNG) {
-#ifdef HAS_PNG
-        std::vector<ui8> imageBytes;
-        WritePngToMemory(
-            (size_t)targetSizeX, (size_t)targetSizeY, pixels, imageBytes
-        );
-        byteArray = env->NewByteArray(imageBytes.size());
-        env->SetByteArrayRegion(
-            byteArray,
-            0,
-            imageBytes.size(),
-            reinterpret_cast<jbyte *>(imageBytes.data())
-        );
-#else
-        // Handle error
-        env->ThrowNew(
-            env->FindClass("java/lang/RuntimeException"),
-            "PNG encoding is not supported on this platform: Could not find "
-            "libpng"
-        );
-        return nullptr;
-#endif
-    } else if (encodingMode == RAW) {
-        env->SetByteArrayRegion(
-            byteArray,
-            0,
-            targetSizeX * targetSizeY * 3,
-            reinterpret_cast<jbyte *>(pixels)
-        );
-    }
-    jobject byteStringObject =
-        env->CallStaticObjectMethod(byteStringClass, copyFromMethod, byteArray);
-    if (byteStringObject == nullptr || env->ExceptionCheck()) {
-        // Handle error
-        if (byteArray != nullptr) {
-            env->DeleteLocalRef(byteArray);
-        }
-        if (pixels != nullptr && resized) {
-            delete[] pixels;
-        }
-        return nullptr;
-    }
-    // Clean up
-    env->DeleteLocalRef(byteArray);
-    if (pixels != nullptr && resized) {
-        delete[] pixels;
-    }
-    return byteStringObject;
+    return makeByteStringFromRgb(
+        env,
+        pixels,
+        textureWidth,
+        textureHeight,
+        targetSizeX,
+        targetSizeY,
+        encodingMode,
+        drawCursor,
+        xPos,
+        yPos
+    );
 }
 
 extern "C" JNIEXPORT jfloatArray JNICALL

--- a/minecraft/mc262/src/main/cpp/include/frame_convert.h
+++ b/minecraft/mc262/src/main/cpp/include/frame_convert.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <jni.h>
+#include "cross_gl.h"
+
+// CPU-only (no GL calls) tail of the capture pipeline, shared by the OpenGL
+// path (framebuffer_capturer.cpp, fed by glReadPixels) and the backend-neutral
+// Blaze3D path (convertCapturedFrameImpl below, fed by
+// CommandEncoder.copyTextureToBuffer). See docs/26_2_vulkan_capture.md.
+//
+// Nearest-neighbour downscale of a tightly packed RGB8 image. Returns a newly
+// allocated buffer the caller owns.
+extern "C" GLubyte *resize_pixels(
+    jint &textureWidth,
+    jint &textureHeight,
+    jint &targetSizeX,
+    jint &targetSizeY,
+    GLubyte *pixels
+);
+
+// Resize (if needed) -> draw cursor -> encode as RAW/PNG -> wrap in a
+// protobuf ByteString. `pixels` is tightly packed RGB8 of srcWidth x srcHeight
+// and stays owned by the caller; any intermediate buffer allocated here is
+// freed here. Returns nullptr (with a pending exception, or none) on failure.
+jobject makeByteStringFromRgb(
+    JNIEnv *env,
+    GLubyte *pixels,
+    jint srcWidth,
+    jint srcHeight,
+    jint targetSizeX,
+    jint targetSizeY,
+    jint encodingMode,
+    jboolean drawCursor,
+    jint xPos,
+    jint yPos
+);

--- a/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
+++ b/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
@@ -13,10 +13,21 @@ import org.lwjgl.opengl.GL30
 // which is mc262-local (src/main/cpp/framebuffer_capturer.cpp + rgb_capture.cpp): 26.2 has no
 // FBO integer to hand over anymore (GpuTexture/RenderTarget replaced Framebuffer), so it's
 // texture-based instead, with the native side owning and caching its own capture FBO (see
-// docs/26_2_phase2_plan.md W3). VULKAN is scaffolding only for now: mc262's Vulkan renderer
-// readback isn't implemented yet, so it fails loudly instead of silently falling back to a
-// slower path in this hot-loop call. ZEROCOPY_TORCH still uses the old mc121-era frameBufferId-based
-// native path and isn't wired up for 26.2 yet either (see initializeZeroCopy below).
+// docs/26_2_phase2_plan.md W3).
+//
+// There are now two capture paths, picked by which rendering backend 26.2 actually came up with
+// (see Blaze3dCapture.CaptureBackend / docs/26_2_vulkan_capture.md):
+//
+//  * OPENGL  - the original one, and everything in this file. GlTexture.glId() -> native
+//              glReadPixels. Untouched, so the GL backend keeps exactly its previous performance.
+//  * BLAZE3D - backend-neutral, and the one that makes Vulkan work. Lives in Blaze3dCapture (in
+//              the client source set, because Blaze3D's GpuDevice/GpuBuffer types are client-only).
+//              It needs no native Vulkan code at all; the only part of it that crosses into JNI is
+//              the RGBA->RGB conversion, convertCapturedFrameImpl below, which reuses the same
+//              resize/cursor/PNG code as the GL path.
+//
+// ZEROCOPY_TORCH still uses the old mc121-era frameBufferId-based native path and isn't wired up
+// for 26.2 on either backend yet (see initializeZeroCopy below).
 object FramebufferCapturer {
     init {
         System.loadLibrary("native-lib")
@@ -35,11 +46,6 @@ object FramebufferCapturer {
         xPos: Int,
         yPos: Int,
     ): ByteString {
-        if (encodingMode == VULKAN) {
-            throw UnsupportedOperationException(
-                "Vulkan frame capture is not implemented yet for mc262 (encodingMode=VULKAN)",
-            )
-        }
         if (encodingMode == ZEROCOPY_TORCH) {
             assert(textureWidth == targetSizeX && textureHeight == targetSizeY)
             return captureFramebufferZerocopyImpl(
@@ -165,13 +171,32 @@ object FramebufferCapturer {
         zZeroToOne: Boolean,
     ): FloatArray
 
+    // The one native entry point of the backend-neutral capture path (Blaze3dCapture, client source
+    // set). It stays declared here because the JNI symbol is bound to this class' name and because
+    // the C++ side of it shares the resize/cursor/PNG code with captureFramebufferImpl above.
+    //
+    // Takes the direct ByteBuffer from GpuBuffer.map(): tightly packed RGBA8 (CommandEncoder sizes
+    // the destination as width * height * format.blockSize(), so there is no row padding).
+    external fun convertCapturedFrameImpl(
+        src: java.nio.ByteBuffer,
+        srcWidth: Int,
+        srcHeight: Int,
+        targetSizeX: Int,
+        targetSizeY: Int,
+        encodingMode: Int,
+        flipVertically: Boolean,
+        drawCursor: Boolean,
+        xPos: Int,
+        yPos: Int,
+    ): ByteString
+
+    // Encoding modes are the wire format (see src/craftground/screen_encoding_modes.py) and are
+    // orthogonal to CaptureBackend: a Vulkan run still produces RAW or PNG bytes in exactly the
+    // same layout. There is deliberately no VULKAN encoding mode - an earlier scaffolding constant
+    // used ordinal 3, which collides with Python's ZEROCOPY_JAX.
     const val RAW = 0
     const val PNG = 1
     const val ZEROCOPY_TORCH = 2
-
-    // mc262-only: Vulkan readback. Not implemented yet (see captureFramebuffer above) -
-    // reserved so the wire format/proto stays stable once it lands.
-    const val VULKAN = 3
 
     var isExtensionAvailable: Boolean = false
     private var hasCheckedExtension: Boolean = false


### PR DESCRIPTION
## Summary
- Adds Vulkan support to mc262's frame capture pipeline via Blaze3D's backend-neutral `copyTextureToBuffer` + `GpuFence` + `GpuBuffer.map()` readback — no native Vulkan JNI needed, since both `GlCommandEncoder` and `VulkanCommandEncoder` implement the same API.
- Capture backend (OpenGL vs Blaze3D-neutral) is now auto-detected from the render texture type at runtime; the old `FramebufferCapturer.VULKAN = 3` encoding-mode constant is removed (it collided with Python's `ZEROCOPY_JAX = 3`). Encoding mode (RAW/PNG/ZEROCOPY) and render backend are now orthogonal — no proto/Python changes.
- `RenderMixin` gains a `submit()`-time BEFORE hook (records the copy + arms the fence) alongside the existing AFTER hook (awaits + reads), since a `GpuFence` captures the submit index at creation and must be created before `submit()` — this adds zero extra submits on the single-eye path.
- Depth capture and stereo both go through the same backend-neutral path; depth linearization for reverse-Z is ported to Kotlin.
- ZEROCOPY (Metal) is designed but intentionally not implemented this round — see `docs/26_2_vulkan_capture.md` for the design and why it's blocked (mc262 GL ZEROCOPY porting + Mojang not enabling `VK_EXT_metal_objects`).
- `build.gradle` gets a `CRAFTGROUND_MC262_GRAPHICS_BACKEND` env hook (forwards to Minecraft's own `--graphicsBackend` launch arg) purely for verification/testing convenience.

## Test plan
- [x] `./gradlew build` succeeds
- [x] ktlint / clang-format / google-java-format all clean
- [x] Ran a real Vulkan/MoltenVK smoke test (`CRAFTGROUND_MC262_GRAPHICS_BACKEND=VULKAN`): backend log shows `Using graphics backend Vulkan, using drivers: 1.2.334 MoltenVK 1.4.2` and `capture path BLAZE3D (color texture VulkanGpuTexture)`; `reset()` + 5 `step()`s completed with no fence hang; captured RAW frame is correctly oriented (HUD/hotbar right-side-up, matching the OpenGL baseline)
- [x] Ran the same smoke test on the OpenGL path to confirm no regression
- [ ] Depth and stereo capture on Vulkan not yet exercised at runtime (same fence/backend machinery as color, lower risk, but untested)
- [ ] Latency benchmarking (Blaze3D path vs native GL path) not yet done — deferred per `docs/26_2_vulkan_capture.md` §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vulkan-compatible frame and depth capture for Minecraft 26.2.
  * Added backend-aware capture selection, GPU synchronization, vertical-flip handling, resizing, cursor rendering, and RAW/PNG output.
  * Added configuration options for selecting the graphics and capture backends.

* **Bug Fixes**
  * Improved capture compatibility across OpenGL and Vulkan rendering paths.
  * Prevented unsupported zero-copy capture modes from running on incompatible backends.

* **Documentation**
  * Added comprehensive Vulkan capture design, configuration, and validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->