### PR TITLE
feat(mc262): port GL ZEROCOPY to texture-based capture, add VK_EXT_metal_objects mixin

### DIFF
--- a/docs/26_2_vulkan_capture.md
+++ b/docs/26_2_vulkan_capture.md
@@ -125,6 +125,7 @@ Python 쪽은 **변경 없음**. wire format이 동일하고 백엔드는 Java �
 |---|---|---|
 | `CRAFTGROUND_CAPTURE_BACKEND` 환경변수 (또는 `-Dcraftground.captureBackend`) = `opengl`\|`blaze3d` | 자동 감지 | 캡처 경로 강제. GL 머신에서 `blaze3d`를 켜서 두 경로를 바이트 단위로 비교하는 용도 |
 | `-Dcraftground.blaze3dFlipVertically=<bool>` | 디바이스가 OpenGL이 아니면 true | 위 flip 추론 무효화 |
+| `-Dcraftground.enableMetalObjects=true` | false | Vulkan 디바이스 생성 시 물리 디바이스가 지원하면 `VK_EXT_metal_objects`를 활성화 (ZEROCOPY (Metal) 선행 작업, 확장 활성화까지만 — 이미지 import는 미구현) |
 
 ## 검증
 
@@ -187,13 +188,50 @@ CraftGround: rendering backend 'Vulkan' -> capture path BLAZE3D (color texture V
 
 ---
 
-## ZEROCOPY (Metal) — 설계만, 미구현
+## ZEROCOPY (Metal) — GL 포팅 + 확장 활성화 완료, 이미지 import는 아직
 
-현재 mc262는 **GL ZEROCOPY조차 포팅되지 않은 상태**(W3 pending)다. 26.2에는
-`initializeZeroCopy`에 넘길 FBO 정수가 더 이상 없기 때문이다. 그래서 Vulkan ZEROCOPY는
-선행조건 자체가 비어 있고, 이번 범위에서 제외했다. 아래는 착수할 때를 위한 메모다.
+### GL ZEROCOPY (텍스처 기반)
 
-### 걸림돌: MC가 `VK_EXT_metal_objects`를 켜지 않는다
+mc262 GL ZEROCOPY가 포팅됐다. mc121은 FBO 정수를 `glCopyTexSubImage2D`에 넘겼지만, mc262는
+RAW/PNG와 마찬가지로 FBO가 없다. `glCopyImageSubData`(GL 4.3 core)도 고려했지만 macOS의
+`OpenGL.framework`는 GL 4.1 core profile까지만 지원해 그 심볼을 안전하게 믿을 수 없어서, 대신
+매 프레임 소스 텍스처를 임시 FBO에 붙이고 `glBlitFramebuffer`(GL 3.0 core, 서로 다른 텍스처
+타겟 간에도 동작)로 IOSurface 백업 `GL_TEXTURE_RECTANGLE_ARB` 텍스처에 복사한다
+(`(colorTexture as GlTexture).glId()` → `targetFbo`). 에이전트용 커서 오버레이는 그 대상 FBO에
+이어서 그린다 — mc121처럼 실제 화면 프레임버퍼에 그리지 않으므로, 사람이 보는 게임 창에는
+나타나지 않는다(RAW 경로의
+`drawCursorCPU`가 CPU 버퍼에만 그리는 것과 같은 원칙).
+
+여전히 OpenGL 백엔드 전용이다 — `EnvironmentInitializer.checkRenderBackend`가 Vulkan +
+`ZEROCOPY_TORCH` 조합을 그대로 fail-fast 처리한다. Depth ZEROCOPY는 mc121에도 없어서
+(`TODO: Depth buffer`) 포팅하지 않았다.
+
+관련 파일: `shared-native/gl-capture/framebuffer_capturer_apple.mm` (+cuda/dummy 변형),
+`jni/jni_macos_zerocopy.cpp`, `FramebufferCapturer.kt`의 `initializeZeroCopy`/
+`captureFramebufferZerocopyImpl`, `MinecraftEnv.kt`의 `sendObservation`(초기화 1회 호출 +
+`ipcHandle` 필드 채우기).
+
+### Vulkan + `VK_EXT_metal_objects`: 확장 활성화까지 완료
+
+`VulkanBackendMetalExtensionMixin` (client mixin)이 `VulkanBackend`의 private
+`createDevice(Collection<String>, VulkanPhysicalDevice, Set<VulkanFeature>)` 호출을
+`@Redirect`로 가로채, 물리 디바이스가 `VK_EXT_metal_objects`를 지원하면 그 확장을
+`deviceExtensions`에 추가한 뒤 원래 메서드를 그대로 호출한다. `@Shadow`로 그 private 메서드를
+직접 호출한다(별도 accessor/invoker 불필요 — mixin이 같은 클래스로 병합되므로).
+
+**opt-in**: `-Dcraftground.enableMetalObjects=true`가 없으면 이 mixin은 아무것도 바꾸지 않는다
+(기존 `deviceExtensions`를 그대로 넘김). Mojang의 디바이스 생성 경로에 개입하는 가장 위험도
+높은 지점이라, 검증 전까지 기본 Vulkan 실행에 영향을 주지 않도록 게이팅했다.
+
+**아직 안 한 것**: 확장이 활성화된 이후의 실제 사용 — IOSurface 백업 `MTLTexture`를
+`VkImportMetalTextureInfoEXT`로 `VkImage`로 import하고, 매 프레임 `vkCmdCopyImage`로 MC의
+color image를 그리로 복사하는 것. 이건 네이티브 Vulkan 코드가 필요한 별도 작업이고, LWJGL에
+`VK_EXT_metal_objects` 바인딩이 있는지부터 확인해야 한다. mach port를 Python에 넘기는 마지막
+단계는 기존 경로(`createMachPortForIOSurface` / `observation_converter.py:254`의
+`initialize_from_mach_port`)를 그대로 재사용할 수 있을 것으로 보인다 — Python 쪽은 IOSurface가
+어느 API로 채워졌는지 신경 쓰지 않기 때문이다.
+
+### 걸림돌이었던 사실 (여전히 유효): MC가 `VK_EXT_metal_objects`를 기본으로 켜지 않는다
 
 `VulkanBackend.java:59`의 필수 확장 목록은 이게 전부다:
 
@@ -210,11 +248,10 @@ VK_EXT_vertex_attribute_divisor, VK_KHR_swapchain
 `VkImportMetalTextureInfoEXT`도 쓸 수 없다. **디바이스 생성 시점에 활성화돼 있어야 하는
 확장**이라 사후에 끼워넣을 수 없다.
 
-### 구현 스케치
+### 남은 구현 스케치
 
-1. `VulkanBackend`의 `deviceExtensions` 리스트에 `VK_EXT_metal_objects`를 주입하는 mixin
-   (`VulkanBackend.java:147` 부근, 물리 디바이스가 지원할 때만).
-   — Mojang의 디바이스 생성 경로에 개입하는 것이므로 이 방식의 위험도가 가장 높다.
+1. ~~`VulkanBackend`의 `deviceExtensions` 리스트에 `VK_EXT_metal_objects`를 주입하는 mixin~~ —
+   완료 (`VulkanBackendMetalExtensionMixin`, opt-in).
 2. IOSurface 백업 MTLTexture를 만들고 (`shared-native/gl-capture/framebuffer_capturer_apple.mm`의
    `createSharedIOSurface`가 이미 한다), 그걸 `VkImage`로 import.
 3. 매 프레임 `vkCmdCopyImage`로 MC의 color image → 우리 이미지.
@@ -225,8 +262,8 @@ VK_EXT_vertex_attribute_divisor, VK_KHR_swapchain
 **Python 쪽은 변경이 필요 없다.** 지금도 `ipc_handle` 바이트를 mach port로만 해석하고,
 IOSurface가 어느 API로 채워졌는지는 신경 쓰지 않는다.
 
-### 선행 작업 순서
+### 남은 선행 작업 순서
 
-1. mc262 GL ZEROCOPY 포팅 (W3) — texture 기반으로 IOSurface 채우기
-2. Vulkan + `VK_EXT_metal_objects` mixin
-3. 위 3~4단계
+1. ~~mc262 GL ZEROCOPY 포팅 (W3) — texture 기반으로 IOSurface 채우기~~ — 완료.
+2. ~~Vulkan + `VK_EXT_metal_objects` mixin~~ — 완료 (opt-in, 기본 off).
+3. 위 2~4단계 (이미지 import, `vkCmdCopyImage`, mach port 전달) — 미착수.

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/MinecraftEnv.kt
@@ -692,10 +692,13 @@ class MinecraftEnv :
             }
         }
         if (initialEnvironment.screenEncodingMode == FramebufferCapturer.ZEROCOPY_TORCH) {
-            // TODO(26_2_phase2_plan.md W3): initializeZeroCopy still expects the mc121-era
-            // FBO-attachment-based signature (colorAttachment/depthAttachment ints from
-            // Framebuffer, which no longer exists). Needs the texture-based native rewrite.
-            printWithTime("ZEROCOPY_TORCH mode requested but not yet ported for 26.2 (W3 pending)")
+            // EnvironmentInitializer.checkRenderBackend already fails fast if this isn't OpenGL.
+            // Guarded by ipcHandle inside initializeZeroCopy, so this only does real work once.
+            FramebufferCapturer.initializeZeroCopy(
+                initialEnvironment.imageSizeX,
+                initialEnvironment.imageSizeY,
+                initialEnvironment.pythonPid,
+            )
         }
 
         // W11 (26_2_phase2_plan.md §1.3/§6.3 Seam A) proposed reading numeric observations off the
@@ -877,6 +880,7 @@ class MinecraftEnv :
                     worldTime = world.gameTime // world tick, monotonic increasing
                     lastDeathMessage = deathMessageCollector?.lastDeathMessage?.firstOrNull() ?: ""
                     image2 = imageByteString2
+                    ipcHandle = FramebufferCapturer.ipcHandle
 
                     if (initialEnvironment.requiresSurroundingBlocks) {
                         val blocks = mutableListOf<ObservationSpace.BlockInfo>()

--- a/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/VulkanBackendMetalExtensionMixin.java
+++ b/minecraft/mc262/src/client/java/com/kyhsgeekcode/minecraftenv/mixin/VulkanBackendMetalExtensionMixin.java
@@ -1,0 +1,62 @@
+package com.kyhsgeekcode.minecraftenv.mixin;
+
+import com.mojang.blaze3d.vulkan.VulkanBackend;
+import com.mojang.blaze3d.vulkan.VulkanPhysicalDevice;
+import com.mojang.blaze3d.vulkan.init.VulkanFeature;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import org.lwjgl.vulkan.VkDevice;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// Prerequisite for Vulkan+Metal ZEROCOPY (importing an IOSurface-backed MTLTexture as a VkImage
+// via VK_EXT_metal_objects) - see the "ZEROCOPY (Metal)" section of docs/26_2_vulkan_capture.md.
+// MC's VulkanBackend.REQUIRED_DEVICE_EXTENSIONS never includes VK_EXT_metal_objects, and it must
+// be enabled at device-creation time (there is no adding it after the fact), so this redirects the
+// call from the public createDevice(window, ...) into the private
+// createDevice(Collection<String>, VulkanPhysicalDevice, Set<VulkanFeature>) overload and extends
+// the extension set there, when the physical device actually supports it.
+//
+// This only enables the extension - it does not implement ZEROCOPY. The MTLTexture import
+// (VkImportMetalTextureInfoEXT) and per-frame vkCmdCopyImage are still unimplemented and require
+// native Vulkan code.
+//
+// Off by default: this intercepts Mojang's Vulkan device-creation path, the riskiest point to
+// touch in the whole capture stack, and hasn't been verified not to break normal Vulkan startup.
+// Pass -Dcraftground.enableMetalObjects=true to opt in for testing.
+@Mixin(VulkanBackend.class)
+public abstract class VulkanBackendMetalExtensionMixin {
+  @Shadow
+  private static VkDevice createDevice(
+      Collection<String> deviceExtensions,
+      VulkanPhysicalDevice physicalDevice,
+      Set<VulkanFeature> vulkanFeatures) {
+    throw new AssertionError("mixed in");
+  }
+
+  @Redirect(
+      method =
+          "createDevice(JLcom/mojang/blaze3d/shaders/ShaderSource;Lcom/mojang/blaze3d/shaders/GpuDebugOptions;Ljava/lang/Runnable;)Lcom/mojang/blaze3d/systems/GpuDevice;",
+      at =
+          @At(
+              value = "INVOKE",
+              target =
+                  "Lcom/mojang/blaze3d/vulkan/VulkanBackend;createDevice(Ljava/util/Collection;Lcom/mojang/blaze3d/vulkan/VulkanPhysicalDevice;Ljava/util/Set;)Lorg/lwjgl/vulkan/VkDevice;"))
+  private static VkDevice minecraftEnv$injectMetalObjectsExtension(
+      Collection<String> deviceExtensions,
+      VulkanPhysicalDevice physicalDevice,
+      Set<VulkanFeature> vulkanFeatures) {
+    if (Boolean.getBoolean("craftground.enableMetalObjects")
+        && physicalDevice.hasDeviceExtension("VK_EXT_metal_objects")) {
+      Set<String> extended = new HashSet<>(deviceExtensions);
+      extended.add("VK_EXT_metal_objects");
+      System.out.println(
+          "CraftGround: enabling VK_EXT_metal_objects (opt-in) for future ZEROCOPY support");
+      return createDevice(extended, physicalDevice, vulkanFeatures);
+    }
+    return createDevice(deviceExtensions, physicalDevice, vulkanFeatures);
+  }
+}

--- a/minecraft/mc262/src/client/resources/minecraftenv.client.mixins.json
+++ b/minecraft/mc262/src/client/resources/minecraftenv.client.mixins.json
@@ -20,7 +20,8 @@
 		"LevelExtractorEntityListenerMixin",
 		"LevelLoadTrackerMixin",
 		"PacketProcessorQueueAccessor",
-		"RenderMixin"
+		"RenderMixin",
+		"VulkanBackendMetalExtensionMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1

--- a/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
+++ b/minecraft/mc262/src/main/java/com/kyhsgeekcode/minecraftenv/FramebufferCapturer.kt
@@ -26,8 +26,10 @@ import org.lwjgl.opengl.GL30
 //              the RGBA->RGB conversion, convertCapturedFrameImpl below, which reuses the same
 //              resize/cursor/PNG code as the GL path.
 //
-// ZEROCOPY_TORCH still uses the old mc121-era frameBufferId-based native path and isn't wired up
-// for 26.2 on either backend yet (see initializeZeroCopy below).
+// ZEROCOPY_TORCH is texture-based like RAW/PNG above (see initializeZeroCopy below) and, like
+// mc121, only supported on the OpenGL backend - EnvironmentInitializer fails fast if it's
+// requested on Vulkan. See docs/26_2_vulkan_capture.md's ZEROCOPY (Metal) section for the Vulkan
+// design (not implemented).
 object FramebufferCapturer {
     init {
         System.loadLibrary("native-lib")
@@ -49,7 +51,7 @@ object FramebufferCapturer {
         if (encodingMode == ZEROCOPY_TORCH) {
             assert(textureWidth == targetSizeX && textureHeight == targetSizeY)
             return captureFramebufferZerocopyImpl(
-                frameBufferId,
+                textureId,
                 targetSizeX,
                 targetSizeY,
                 drawCursor,
@@ -124,14 +126,12 @@ object FramebufferCapturer {
     fun initializeZeroCopy(
         width: Int,
         height: Int,
-        colorAttachment: Int,
-        depthAttachment: Int,
         pythonPid: Int,
     ) {
         if (ipcHandle != ByteString.EMPTY) {
             return
         }
-        val result = initializeZerocopyImpl(width, height, colorAttachment, depthAttachment, pythonPid)
+        val result = initializeZerocopyImpl(width, height, pythonPid)
         if (result == null || result == ByteString.EMPTY) {
             println("FramebufferCapturer: ZeroCopy initialization failed")
             throw RuntimeException("ZeroCopy initialization failed")
@@ -142,13 +142,14 @@ object FramebufferCapturer {
     external fun initializeZerocopyImpl(
         width: Int,
         height: Int,
-        colorAttachment: Int,
-        depthAttachment: Int,
         pythonPid: Int,
     ): ByteString?
 
+    // sourceTextureId is the GL texture id of the main color target (like captureFramebufferImpl
+    // above) - no FBO is bound; the native side copies texture-to-texture into the IOSurface-backed
+    // rectangle texture (see shared-native/gl-capture/framebuffer_capturer_apple.mm).
     external fun captureFramebufferZerocopyImpl(
-        frameBufferId: Int,
+        sourceTextureId: Int,
         targetSizeX: Int,
         targetSizeY: Int,
         drawCursor: Boolean,

--- a/shared-native/gl-capture/framebuffer_capturer_apple.mm
+++ b/shared-native/gl-capture/framebuffer_capturer_apple.mm
@@ -2,10 +2,14 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #define GL_SILENCE_DEPRECATION
-#include <OpenGL/OpenGL.h>
-#include <OpenGL/gl.h>
+#include <OpenGL/OpenGL.h> // CGLGetCurrentContext / CGLTexImageIOSurface2D
 #include <servers/bootstrap.h>
 
+// cross_gl.h (rather than the legacy <OpenGL/gl.h>) for glBindFramebuffer /
+// glFramebufferTexture2D / glBlitFramebuffer - see the comment on targetFbo
+// below for why this needs GL 3.0 core FBO entry points.
+#include "cross_gl.h"
+#include "cursor.h"
 #include "framebuffer_capturer_apple.h"
 
 IOSurfaceRef createSharedIOSurface(int width, int height) {
@@ -80,6 +84,23 @@ createMachPortForIOSurface(IOSurfaceRef ioSurface, int python_pid) {
 static IOSurfaceRef ioSurface;
 static bool initialized = false;
 static GLuint textureID;
+// Destination FBO wrapping textureID (used both for the blit target and for
+// the cursor overlay - see below) and a source FBO the caller's texture gets
+// attached to each frame. Blit rather than glCopyImageSubData: macOS's
+// OpenGL.framework tops out around a GL 4.1 core profile, and
+// glCopyImageSubData is only core as of GL 4.3 (GL_ARB_copy_image support is
+// not guaranteed there), whereas glBlitFramebuffer has been core since GL 3.0
+// and blits between differing texture targets (GL_TEXTURE_2D source,
+// GL_TEXTURE_RECTANGLE dest here) without needing them to match.
+static GLuint targetFbo;
+static GLuint sourceFbo;
+
+// On 26.2 there is no long-lived FBO id available from Java for the main
+// color target (the RAW/PNG path is texture-based, see
+// docs/26_2_vulkan_capture.md), so the synthetic agent cursor is composited
+// onto this copy of the frame after the blit below, rather than onto the live
+// framebuffer as mc121 does. This only affects what the agent sees via
+// IOSurface, not what's shown in the game window.
 
 // TODO: Depth buffer
 int initializeIoSurface(
@@ -89,22 +110,17 @@ int initializeIoSurface(
         return 0;
     }
 
-    // If were to use colorAttachment and depthAttachment, they
-    // should be first converted to GL_TEXTURE_RECTANGLE_ARB, from GL_TEXTURE_2D
-    // Therefore, use glCopyTexSubImage2D to copy the contents of the
-    // framebuffer to ARB textures
-
     // Generate a texture
     glGenTextures(1, &textureID);
     ioSurface = createSharedIOSurface(width, height);
     mach_port_t machPort = createMachPortForIOSurface(ioSurface, python_pid);
     printf("\n\nmachPort: %u\n\n\n", machPort);
     fflush(stdout);
-    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, textureID);
+    glBindTexture(GL_TEXTURE_RECTANGLE, textureID);
     CGLContextObj cglContext = CGLGetCurrentContext();
     CGLTexImageIOSurface2D(
         cglContext,
-        GL_TEXTURE_RECTANGLE_ARB,
+        GL_TEXTURE_RECTANGLE,
         GL_RGBA,
         width,
         height,
@@ -113,6 +129,20 @@ int initializeIoSurface(
         ioSurface,
         0
     );
+
+    glGenFramebuffers(1, &targetFbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, targetFbo);
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, textureID, 0
+    );
+    assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    // Re-attached to the caller's texture every frame in
+    // copyFramebufferToIOSurface (that texture id can change across resizes),
+    // so it's left incomplete/empty here.
+    glGenFramebuffers(1, &sourceFbo);
+
     initialized = true;
     const int size = sizeof(machPort);
     void *bytes = malloc(size);
@@ -124,32 +154,51 @@ int initializeIoSurface(
     return size;
 }
 
-void copyFramebufferToIOSurface(int width, int height) {
-    // GLuint renderedTextureId;
-    // glGetFramebufferAttachmentParameteriv(
-    //     GL_READ_FRAMEBUFFER,
-    //     GL_COLOR_ATTACHMENT0,
-    //     GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME,
-    //     (GLint *)&renderedTextureId
-    // );
-    // glBindTexture(GL_TEXTURE_2D, renderedTextureId);
-    // int textureWidth, textureHeight;
-    // glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH,
-    // &textureWidth); glGetTexLevelParameteriv(
-    //     GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &textureHeight
-    // );
-    // printf("width: %d, height: %d\n", textureWidth, textureHeight);
-    // glViewport(0, 0, width, height);
+void copyFramebufferToIOSurface(
+    int sourceTextureId,
+    int width,
+    int height,
+    bool drawCursor,
+    int mouseX,
+    int mouseY
+) {
+    // mc262's main color target is a plain GL_TEXTURE_2D (see
+    // EnvironmentInitializer's Blaze3D backend detection); blit it into the
+    // IOSurface-backed GL_TEXTURE_RECTANGLE texture without ever needing
+    // an FBO id from the caller.
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, sourceFbo);
+    glFramebufferTexture2D(
+        GL_READ_FRAMEBUFFER,
+        GL_COLOR_ATTACHMENT0,
+        GL_TEXTURE_2D,
+        sourceTextureId,
+        0
+    );
+    assert(
+        glCheckFramebufferStatus(GL_READ_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE
+    );
     glReadBuffer(GL_COLOR_ATTACHMENT0);
-    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, textureID);
-    // GLenum status = glCheckFramebufferStatus(GL_READ_FRAMEBUFFER);
-    // if (status != GL_FRAMEBUFFER_COMPLETE) {
-    //     printf("Framebuffer is not complete! Status: 0x%x\n", status);
-    //     fflush(stdout);
-    //     assert(status == GL_FRAMEBUFFER_COMPLETE);
-    // }
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, targetFbo);
+    glBlitFramebuffer(
+        0,
+        0,
+        width,
+        height,
+        0,
+        0,
+        width,
+        height,
+        GL_COLOR_BUFFER_BIT,
+        GL_NEAREST
+    );
     assert(glGetError() == GL_NO_ERROR);
-    // assert(width == textureWidth);
-    // assert(height == textureHeight);
-    glCopyTexSubImage2D(GL_TEXTURE_RECTANGLE_ARB, 0, 0, 0, 0, 0, width, height);
+
+    if (drawCursor) {
+        // Still bound as GL_DRAW_FRAMEBUFFER from the blit above.
+        glViewport(0, 0, width, height);
+        renderCursor(mouseX, mouseY);
+    }
+
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 }

--- a/shared-native/gl-capture/framebuffer_capturer_cuda.cpp
+++ b/shared-native/gl-capture/framebuffer_capturer_cuda.cpp
@@ -8,14 +8,8 @@ static void *sharedCudaColorMem = nullptr;
 static bool initialized = false;
 static int rendering_gpu = -1;
 
-// TODO: depth attachment
 int initialize_cuda_ipc(
-    int width,
-    int height,
-    int colorAttachment,
-    int depthAttachment,
-    cudaIpcMemHandle_t *memHandlePtr,
-    int *deviceId
+    int width, int height, cudaIpcMemHandle_t *memHandlePtr, int *deviceId
 ) {
     if (initialized) {
         fprintf(stderr, "CUDA IPC already initialized\n");
@@ -81,57 +75,13 @@ int initialize_cuda_ipc(
     return sizeof(cudaIpcMemHandle_t);
 }
 
-void checkAndPrintGLError() {
-    GLenum error = glGetError();
-    while (error != GL_NO_ERROR) {
-        printf("OpenGL Error: 0x%x\n", error);
-        error = glGetError();
-    }
-    fflush(stdout);
-}
-
-void copyFramebufferToCudaSharedMemory(int width, int height) {
-    GLuint renderedTextureId;
-    glGetFramebufferAttachmentParameteriv(
-        GL_READ_FRAMEBUFFER,
-        GL_COLOR_ATTACHMENT0,
-        GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME,
-        (GLint *)&renderedTextureId
-    );
-    checkAndPrintGLError();
-    glBindTexture(GL_TEXTURE_2D, renderedTextureId);
-    checkAndPrintGLError();
-    int textureWidth, textureHeight;
-    int format;
-    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &textureWidth);
-    checkAndPrintGLError();
-    glGetTexLevelParameteriv(
-        GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &textureHeight
-    );
-    checkAndPrintGLError();
-    glGetTexLevelParameteriv(
-        GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &format
-    );
-    checkAndPrintGLError();
-    // printf("width: %d, height: %d, format: %d\n", textureWidth,
-    // textureHeight, format); fflush(stdout);
-    assert(format == GL_RGBA8);
-    // printf("width: %d, height: %d\n", textureWidth, textureHeight);
-    glViewport(0, 0, width, height);
-    checkAndPrintGLError();
-    glReadBuffer(GL_COLOR_ATTACHMENT0);
-    checkAndPrintGLError();
-    GLenum status = glCheckFramebufferStatus(GL_READ_FRAMEBUFFER);
-    checkAndPrintGLError();
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
-        printf("Framebuffer is not complete! Status: 0x%x\n", status);
-        fflush(stdout);
-        assert(status == GL_FRAMEBUFFER_COMPLETE);
-    }
-    fflush(stdout);
-    assert(width == textureWidth);
-    assert(height == textureHeight);
-
+void copyFramebufferToCudaSharedMemory(
+    int sourceTextureId, int width, int height
+) {
+    // mc262's main color target is a texture handed directly from Java (see
+    // docs/26_2_vulkan_capture.md - the RAW/PNG path is texture-based, not
+    // FBO-based), so it's registered with CUDA directly instead of being
+    // looked up from a bound read framebuffer's attachment.
     assert(sharedCudaColorMem != nullptr);
     assert(initialized);
 
@@ -142,7 +92,7 @@ void copyFramebufferToCudaSharedMemory(int width, int height) {
     // register the texture with CUDA
     err = cudaGraphicsGLRegisterImage(
         &cudaResource,
-        renderedTextureId,
+        sourceTextureId,
         GL_TEXTURE_2D,
         cudaGraphicsRegisterFlagsReadOnly
     );

--- a/shared-native/gl-capture/include/framebuffer_capturer_apple.h
+++ b/shared-native/gl-capture/include/framebuffer_capturer_apple.h
@@ -3,11 +3,15 @@
 #define __FRAMEBUFFER_CAPTURER_APPLE_H__
 
 int initializeIoSurface(
+    int width, int height, void **return_value, int python_pid
+);
+void copyFramebufferToIOSurface(
+    int sourceTextureId,
     int width,
     int height,
-    void **return_value,
-    int python_pid
-); // , int colorAttachment, int depthAttachment
-void copyFramebufferToIOSurface(int width, int height);
+    bool drawCursor,
+    int mouseX,
+    int mouseY
+);
 
 #endif

--- a/shared-native/gl-capture/include/framebuffer_capturer_cuda.h
+++ b/shared-native/gl-capture/include/framebuffer_capturer_cuda.h
@@ -8,14 +8,11 @@
 #include <driver_types.h>
 
 int initialize_cuda_ipc(
-    int width,
-    int height,
-    int colorAttachment,
-    int depthAttachment,
-    cudaIpcMemHandle_t *memHandlePtr,
-    int *deviceId
+    int width, int height, cudaIpcMemHandle_t *memHandlePtr, int *deviceId
 );
 
-void copyFramebufferToCudaSharedMemory(int width, int height);
+void copyFramebufferToCudaSharedMemory(
+    int sourceTextureId, int width, int height
+);
 
 #endif

--- a/shared-native/gl-capture/jni/jni_cuda_zerocopy.cpp
+++ b/shared-native/gl-capture/jni/jni_cuda_zerocopy.cpp
@@ -12,13 +12,7 @@
 
 extern "C" JNIEXPORT jobject JNICALL
 Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_initializeZerocopyImpl(
-    JNIEnv *env,
-    jclass clazz,
-    jint width,
-    jint height,
-    jint colorAttachment,
-    jint depthAttachment,
-    jint python_pid
+    JNIEnv *env, jclass clazz, jint width, jint height, jint python_pid
 ) {
     if (!initCursorTexture()) {
         fflush(stderr);
@@ -50,9 +44,7 @@ Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_initializeZerocopyImpl(
 
     cudaIpcMemHandle_t memHandle;
     int deviceId = -1;
-    int size = initialize_cuda_ipc(
-        width, height, colorAttachment, depthAttachment, &memHandle, &deviceId
-    );
+    int size = initialize_cuda_ipc(width, height, &memHandle, &deviceId);
 
     if (size < 0) {
         fflush(stderr);
@@ -96,22 +88,21 @@ extern "C" JNIEXPORT jobject JNICALL
 Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_captureFramebufferZerocopyImpl(
     JNIEnv *env,
     jclass clazz,
-    jint frameBufferId,
+    jint sourceTextureId,
     jint targetSizeX,
     jint targetSizeY,
     jboolean drawCursor,
     jint mouseX,
     jint mouseY
 ) {
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, frameBufferId);
-
-    if (drawCursor) {
-        renderCursor(mouseX, mouseY);
-    }
-
-    // CUDA IPC handles are used to share the framebuffer with the Python side
-    // However copy is required anyway
-    copyFramebufferToCudaSharedMemory(targetSizeX, targetSizeY);
+    // CUDA IPC handles are used to share the framebuffer with the Python side.
+    // The cursor overlay isn't composited for this path (see
+    // copyFramebufferToCudaSharedMemory) - drawCursor/mouseX/mouseY are kept
+    // as parameters only for JNI signature parity with the other zerocopy
+    // implementations.
+    copyFramebufferToCudaSharedMemory(
+        sourceTextureId, targetSizeX, targetSizeY
+    );
     return nullptr;
 }
 #endif

--- a/shared-native/gl-capture/jni/jni_dummy_zerocopy.cpp
+++ b/shared-native/gl-capture/jni/jni_dummy_zerocopy.cpp
@@ -23,13 +23,7 @@ Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_captureFramebufferImpl(
 // CPU)
 extern "C" JNIEXPORT jobject JNICALL
 Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_initializeZerocopyImpl(
-    JNIEnv *env,
-    jclass clazz,
-    jint width,
-    jint height,
-    jint colorAttachment,
-    jint depthAttachment,
-    jint python_pid
+    JNIEnv *env, jclass clazz, jint width, jint height, jint python_pid
 ) {
     // jclass byteStringClass =
     // env->FindClass("com/google/protobuf/ByteString");
@@ -53,7 +47,7 @@ extern "C" JNIEXPORT jobject JNICALL
 Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_captureFramebufferZerocopyImpl(
     JNIEnv *env,
     jclass clazz,
-    jint frameBufferId,
+    jint sourceTextureId,
     jint targetSizeX,
     jint targetSizeY,
     jboolean drawCursor,
@@ -63,8 +57,8 @@ Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_captureFramebufferZerocop
     return Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_captureFramebufferImpl(
         env,
         clazz,
+        sourceTextureId,
         0,
-        frameBufferId,
         targetSizeX,
         targetSizeY,
         targetSizeX,

--- a/shared-native/gl-capture/jni/jni_macos_zerocopy.cpp
+++ b/shared-native/gl-capture/jni/jni_macos_zerocopy.cpp
@@ -8,13 +8,7 @@
 
 extern "C" JNIEXPORT jobject JNICALL
 Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_initializeZerocopyImpl(
-    JNIEnv *env,
-    jclass clazz,
-    jint width,
-    jint height,
-    jint colorAttachment,
-    jint depthAttachment,
-    jint python_pid
+    JNIEnv *env, jclass clazz, jint width, jint height, jint python_pid
 ) {
     if (!initCursorTexture()) {
         fflush(stderr);
@@ -67,22 +61,18 @@ extern "C" JNIEXPORT jobject JNICALL
 Java_com_kyhsgeekcode_minecraftenv_FramebufferCapturer_captureFramebufferZerocopyImpl(
     JNIEnv *env,
     jclass clazz,
-    jint frameBufferId,
+    jint sourceTextureId,
     jint targetSizeX,
     jint targetSizeY,
     jboolean drawCursor,
     jint mouseX,
     jint mouseY
 ) {
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, frameBufferId);
-    if (drawCursor) {
-        renderCursor(mouseX, mouseY);
-    }
-
-    // It could have been that the rendered image is already being shared,
-    // but the original texture is TEXTURE_2D, so we need to convert to
-    // TEXTURE_2D_RECTANGLE_ARB
-    copyFramebufferToIOSurface(targetSizeX, targetSizeY);
+    // The rendered image is a plain GL_TEXTURE_2D, so it's copied into the
+    // IOSurface-backed GL_TEXTURE_2D_RECTANGLE_ARB texture directly.
+    copyFramebufferToIOSurface(
+        sourceTextureId, targetSizeX, targetSizeY, drawCursor, mouseX, mouseY
+    );
     return nullptr;
 }
 #endif


### PR DESCRIPTION
## Summary
- Ports mc121's FBO-based GL ZEROCOPY (IOSurface) capture to mc262's texture-based capture model, using `glBlitFramebuffer` (GL 3.0 core, portable) instead of FBO-integer readback. Covers Apple/CUDA/dummy JNI backends.
- Adds `VulkanBackendMetalExtensionMixin`, an opt-in (`-Dcraftground.enableMetalObjects=true`) mixin that injects `VK_EXT_metal_objects` into `VulkanBackend`'s device extension set when the physical device supports it — a prerequisite for a future Vulkan+Metal zerocopy path.
- Updates `docs/26_2_vulkan_capture.md` to reflect what's done vs. still pending (MTLTexture import via `VkImportMetalTextureInfoEXT` and per-frame `vkCmdCopyImage` are explicitly out of scope here).

## Test plan
- [x] `./gradlew build` passes (Kotlin, Java incl. new mixin, native C++ for all three JNI backends)
- [x] `clang-format`/`google-java-format`/`ktlint` applied per `dev_tools.sh` conventions
- [x] Runtime smoke test (via `minecraft-simulator-benchmark`'s `craftground` harness): OpenGL backend + `ZEROCOPY_TORCH` — mach port handoff succeeds, Python receives a live `mps:0` torch tensor, 5 steps run, captured frame matches expected pixels (HUD + agent cursor visible, correct colors)
- [x] Runtime smoke test: Vulkan backend with `-Dcraftground.enableMetalObjects=true` — log shows `CraftGround: enabling VK_EXT_metal_objects (opt-in) for future ZEROCOPY support`, device creation succeeds, rendering/capture proceeds normally across 5 steps
- [x] Runtime smoke test: Vulkan backend without the flag — no extension-enable log line, identical behavior to before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)